### PR TITLE
Add back `pre-commit`

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -55,6 +55,7 @@ jobs:
         python -m pip install -U pip
         pip install -U setuptools wheel
         pip install -U -r requirements.txt -r requirements_dev.txt
+        pip install -e .
         pip install safety
 
     - name: Run pylint

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -9,61 +9,65 @@ on:
 
 jobs:
 
-  # pre-commit:
-  #   runs-on: ubuntu-latest
-  #   # timeout-minutes: 2
+  pre-commit:
+    runs-on: ubuntu-latest
+    # timeout-minutes: 2
 
-  #   steps:
-  #   - uses: actions/checkout@v2
+    steps:
+    - uses: actions/checkout@v2
 
-  #   - name: Set up Python 3.9
-  #     uses: actions/setup-python@v2
-  #     with:
-  #       python-version: 3.9
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
 
-  #   - name: Install dependencies
-  #     run: |
-  #       python -m pip install --upgrade pip
-  #       pip install -U setuptools wheel
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -U setuptools wheel
 
-  #       while IFS="" read -r line || [ -n "${line}" ]; do
-  #         if [[ "${line}" =~ ^pre-commit.*$ ]]; then
-  #           pre_commit="${line}"
-  #         elif [[ "${line}" =~ ^invoke.*$ ]]; then
-  #           invoke="${line}"
-  #         fi
-  #       done < requirements_dev.txt
+        while IFS="" read -r line || [ -n "${line}" ]; do
+          if [[ "${line}" =~ ^pre-commit.*$ ]]; then
+            pre_commit="${line}"
+          fi
+        done < requirements_dev.txt
 
-  #       pip install ${pre_commit} ${invoke}
+        pip install ${pre_commit}
 
-  #   - name: Test with pre-commit
-  #     run: SKIP=pylint pre-commit run --all-files
+    - name: Test with pre-commit
+      run: SKIP=pylint,pylint-strategies,pylint-tests pre-commit run --all-files
 
-  # pylint-safety:
-  #   runs-on: ubuntu-latest
+  pylint-safety:
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #   - uses: actions/checkout@v2
-  #     with:
-  #       fetch-depth: 2
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 2
 
-  #   - name: Set up Python 3.9
-  #     uses: actions/setup-python@v2
-  #     with:
-  #       python-version: 3.9
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
 
-  #   - name: Install dependencies
-  #     run: |
-  #       python -m pip install -U pip
-  #       pip install -U setuptools wheel
-  #       pip install -U -r requirements.txt -r requirements_dev.txt
-  #       pip install safety
+    - name: Install dependencies
+      run: |
+        python -m pip install -U pip
+        pip install -U setuptools wheel
+        pip install -U -r requirements.txt -r requirements_dev.txt
+        pip install safety
 
-  #   - name: Run pylint
-  #     run: pylint --rcfile=pyproject.toml *.py oteapi
+    - name: Run pylint
+      run: pylint --rcfile=.pylintrc --ignore-paths=oteapi/strategies/,tests/ --extension-pkg-whitelist='pydantic' -- *.py oteapi
 
-  #   - name: Run safety
-  #     run: pip freeze | safety check --stdin
+    - name: Run pylint - oteapi/strategies
+      run: pylint --rcfile=.pylintrc --extension-pkg-whitelist='pydantic' --disable=R,C -- oteapi/strategies
+
+    - name: Run pylint - tests
+      run: pylint --rcfile=.pylintrc --extension-pkg-whitelist='pydantic' --disable=C0415,W0621 -- tests
+
+    - name: Run safety
+      run: pip freeze | safety check --stdin
 
   pytest:
     runs-on: ubuntu-latest

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,51 @@
+# To install the git pre-commit hook run:
+#   pre-commit install
+# To update the pre-commit hooks run:
+#   pre-commit autoupdate
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.1.0
+    hooks:
+    - id: end-of-file-fixer
+    - id: debug-statements
+    - id: check-yaml
+      name: Check YAML
+    - id: check-json
+      name: Check JSON
+    - id: check-toml
+      name: Check TOML
+    - id: check-symlinks
+    - id: destroyed-symlinks
+    - id: requirements-txt-fixer
+      name: Fix requirements*.txt
+      files: ^requirements.*\.txt$
+    - id: trailing-whitespace
+      args: [--markdown-linebreak-ext=md]
+
+  - repo: https://github.com/timothycrosley/isort
+    rev: 5.10.0
+    hooks:
+      - id: isort
+        args: ["--profile", "black", "--filter-files", "--skip-gitignore"]
+
+  - repo: https://github.com/ambv/black
+    rev: 21.10b0
+    hooks:
+    - id: black
+
+  - repo: https://github.com/PyCQA/bandit
+    rev: 1.7.0
+    hooks:
+    - id: bandit
+      files: ^oteapi/app/.*$
+
+  - repo: local
+    hooks:
+    - id: pylint-app
+      name: pylint - app/
+      entry: pylint
+      args: ["--rcfile=.pylintrc", "--extension-pkg-whitelist='pydantic'"]
+      language: python
+      types: [python]
+      require_serial: true
+      files: ^oteapi/.*$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
       files: ^oteapi/.*$
       exclude: ^oteapi/strategies/.*$
     - id: pylint-strategies
-      name: pylint - strategies/
+      name: pylint - oteapi/strategies/
       entry: pylint
       args: ["--rcfile=.pylintrc", "--extension-pkg-whitelist='pydantic'", "--disable=R,C"]
       language: python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,15 +46,15 @@ repos:
 
   - repo: local
     hooks:
-    - id: pylint-oteapi
-      name: pylint - oteapi/[^strategies]
+    - id: pylint
+      name: pylint
       entry: pylint
       args: ["--rcfile=.pylintrc", "--extension-pkg-whitelist='pydantic'"]
       language: python
       types: [python]
       require_serial: true
-      files: ^oteapi/.*$
-      exclude: ^oteapi/strategies/.*$
+      files: ^.*$
+      exclude: ^(tests|oteapi/strategies)/.*$
     - id: pylint-strategies
       name: pylint - oteapi/strategies/
       entry: pylint
@@ -63,3 +63,11 @@ repos:
       types: [python]
       require_serial: true
       files: ^oteapi/strategies/.*$
+    - id: pylint-tests
+      name: pylint - tests
+      entry: pylint
+      args: ["--rcfile=.pylintrc", "--extension-pkg-whitelist='pydantic'", "--disable=C0415,W0621"]
+      language: python
+      types: [python]
+      require_serial: true
+      files: ^tests/.*$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,12 +10,8 @@ repos:
     - id: debug-statements
     - id: check-yaml
       name: Check YAML
-    - id: check-json
-      name: Check JSON
     - id: check-toml
       name: Check TOML
-    - id: check-symlinks
-    - id: destroyed-symlinks
     - id: requirements-txt-fixer
       name: Fix requirements*.txt
       files: ^requirements.*\.txt$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,16 @@ repos:
     rev: 1.7.1
     hooks:
     - id: bandit
+      args: ["-r"]
       files: ^oteapi/.*$
+
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.931
+    hooks:
+    - id: mypy
+      exclude: ^tests/.*$
+      additional_dependencies:
+        - "types-requests"
 
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,18 +23,18 @@ repos:
       args: [--markdown-linebreak-ext=md]
 
   - repo: https://github.com/timothycrosley/isort
-    rev: 5.10.0
+    rev: 5.10.1
     hooks:
-      - id: isort
-        args: ["--profile", "black", "--filter-files", "--skip-gitignore"]
+    - id: isort
+      args: ["--profile", "black", "--filter-files", "--skip-gitignore"]
 
   - repo: https://github.com/ambv/black
-    rev: 21.10b0
+    rev: 21.12b0
     hooks:
     - id: black
 
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.7.0
+    rev: 1.7.1
     hooks:
     - id: bandit
       files: ^oteapi/app/.*$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,12 +37,12 @@ repos:
     rev: 1.7.1
     hooks:
     - id: bandit
-      files: ^oteapi/app/.*$
+      files: ^oteapi/.*$
 
   - repo: local
     hooks:
-    - id: pylint-app
-      name: pylint - app/
+    - id: pylint
+      name: pylint
       entry: pylint
       args: ["--rcfile=.pylintrc", "--extension-pkg-whitelist='pydantic'"]
       language: python

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,11 +41,20 @@ repos:
 
   - repo: local
     hooks:
-    - id: pylint
-      name: pylint
+    - id: pylint-oteapi
+      name: pylint - oteapi/[^strategies]
       entry: pylint
       args: ["--rcfile=.pylintrc", "--extension-pkg-whitelist='pydantic'"]
       language: python
       types: [python]
       require_serial: true
       files: ^oteapi/.*$
+      exclude: ^oteapi/strategies/.*$
+    - id: pylint-strategies
+      name: pylint - strategies/
+      entry: pylint
+      args: ["--rcfile=.pylintrc", "--extension-pkg-whitelist='pydantic'", "--disable=R,C"]
+      language: python
+      types: [python]
+      require_serial: true
+      files: ^oteapi/strategies/.*$

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 
 ## Content
 
-
 * [About OTEAPI Core](#about-oteapi-core)
 * [Types of strategies](#types-of-strategies)
   * [Download strategy](#download-strategy)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ OTEAPI Core includes:
 ### Download strategy
 
 Download strategy patterns use a given protocol to download content into the data cache.
-They are configured with the `ResourceConfig` data model, using the scheme of the `downloadUrl` field for strategy selection. 
+They are configured with the `ResourceConfig` data model, using the scheme of the `downloadUrl` field for strategy selection.
 The `configuration` field can be used to configure how the downloaded content is stored in the cache using the `DownloadConfig` data model.
 
 Standard downloaded strategies: *file*, *https*, *http*, *sftp*, *ftp*

--- a/oteapi/datacache/__init__.py
+++ b/oteapi/datacache/__init__.py
@@ -4,5 +4,4 @@ Get the `DataCache`.
 """
 from .datacache import DataCache
 
-
 __all__ = ("DataCache",)

--- a/oteapi/datacache/datacache.py
+++ b/oteapi/datacache/datacache.py
@@ -16,14 +16,15 @@ import asyncio
 import hashlib
 import json
 import os
-from pathlib import Path
 import tempfile
 from contextlib import contextmanager
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from diskcache import Cache as DiskCache
-from oteapi.models import DownloadConfig
 from pydantic import Extra
+
+from oteapi.models import DownloadConfig
 
 if TYPE_CHECKING:
     from typing import Any, Optional, Union
@@ -94,7 +95,9 @@ class DataCache:
     """
 
     def __init__(
-        self, config: "Union[DownloadConfig, dict]" = None, cache_dir: "Optional[Union[Path, str]]" = None
+        self,
+        config: "Union[DownloadConfig, dict]" = None,
+        cache_dir: "Optional[Union[Path, str]]" = None,
     ) -> None:
         if config is None:
             self.config = DownloadConfig()

--- a/oteapi/datacache/datacache.py
+++ b/oteapi/datacache/datacache.py
@@ -26,14 +26,14 @@ from pydantic import Extra
 from oteapi.models import DownloadConfig
 
 if TYPE_CHECKING:
-    from typing import Any, Optional, Union
+    from typing import Any, Iterator, Optional, Type, Union
 
 
 def gethash(
     value: "Any",
     hashtype: str = "sha256",
     encoding: str = "utf-8",
-    json_encoder: "Optional[json.JSONEncoder]" = None,
+    json_encoder: "Optional[Type[json.JSONEncoder]]" = None,
 ) -> str:
     """Return a hash of `value`.
 
@@ -200,7 +200,7 @@ class DataCache:
         suffix: "Optional[str]" = None,
         directory: "Optional[str]" = None,
         delete: bool = True,
-    ) -> Path:
+    ) -> "Iterator[Path]":
         """Write the value for `key` to file and return the filename.
 
         The file is created in the default directory for temporary

--- a/oteapi/datacache/datacache.py
+++ b/oteapi/datacache/datacache.py
@@ -15,7 +15,6 @@ Features:
 import asyncio
 import hashlib
 import json
-import os
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
@@ -63,9 +62,9 @@ def gethash(
             sort_keys=True,
         ).encode(encoding)
 
-    h = hashlib.new(hashtype)
-    h.update(data)
-    return h.hexdigest()
+    hash_ = hashlib.new(hashtype)
+    hash_.update(data)
+    return hash_.hexdigest()
 
 
 def asyncrun(func, *args) -> "Any":
@@ -117,13 +116,13 @@ class DataCache:
         else:
             self.cache_dir = Path(tempfile.gettempdir()).resolve() / cache_dir
 
-        self.dc = DiskCache(directory=self.cache_dir)
+        self.datacache = DiskCache(directory=self.cache_dir)
 
     def __contains__(self, key) -> bool:
-        return key in self.dc
+        return key in self.datacache
 
     def __len__(self) -> int:
-        return len(self.dc)
+        return len(self.datacache)
 
     def __getitem__(self, key) -> "Any":
         return self.get(key)
@@ -133,14 +132,14 @@ class DataCache:
 
     def __delitem__(self, key) -> None:
         def deleter(key):
-            del self.dc[key]
+            del self.datacache[key]
 
         asyncrun(deleter, key)
 
     def __del__(self) -> None:
         def closer():
-            self.dc.expire()
-            self.dc.close()
+            self.datacache.expire()
+            self.datacache.close()
 
         asyncrun(closer)
 
@@ -180,7 +179,7 @@ class DataCache:
 
         # Needed because asyncio.run() does not support keyword arguments
         def setter(key, value, expire, tag):
-            self.dc.set(key, value, expire=expire, tag=tag)
+            self.datacache.set(key, value, expire=expire, tag=tag)
 
         asyncrun(setter, key, value, expire, tag)
 
@@ -188,28 +187,28 @@ class DataCache:
 
     def get(self, key: str) -> "Any":
         """Return the value corresponding to key."""
-        if key not in self.dc:
+        if key not in self.datacache:
             raise KeyError(key)
-        return asyncrun(self.dc.get, key)
+        return asyncrun(self.datacache.get, key)
 
     @contextmanager
-    def getfile(
+    def getfile(  # pylint: disable=too-many-arguments
         self,
         key: str,
-        filename: "Optional[str]" = None,
+        filename: "Optional[Union[Path, str]]" = None,
         prefix: "Optional[str]" = None,
         suffix: "Optional[str]" = None,
         directory: "Optional[str]" = None,
         delete: bool = True,
-    ) -> str:
+    ) -> Path:
         """Write the value for `key` to file and return the filename.
 
         The file is created in the default directory for temporary
         files (which can be controlled by the TEMPDIR, TEMP or TMP
-        environment variables).  It is readable and writable only for
+        environment variables). It is readable and writable only for
         the current user.
 
-        This method is intended to be used in a with statement, to
+        This method is intended to be used in a `with` statement, to
         automatically delete the file when leaving the context.
 
         Example:
@@ -217,50 +216,50 @@ class DataCache:
         ```python
         cache = DataCache()
         with cache.getfile('mykey') as filename:
-             # do something with filename...
+            # do something with filename...
         # filename is deleted
         ```
 
         Args:
-            key: key of value to write to file
-            filename: full path to created file.  If not given, a unique
+            key: Key of value to write to file
+            filename: Full path to created file. If not given, a unique
                 filename will be created.
-            prefix: prefix to prepend to the returned file name (default
+            prefix: Prefix to prepend to the returned file name (default
                 is "oteapi-download-").
-            suffix: suffix to append to the returned file name.
-            directory: file directory if `filename` is None.
-            delete: whether to automatically delete created file when
+            suffix: Suffix to append to the returned file name.
+            directory: File directory if `filename` is None.
+            delete: Whether to automatically delete created file when
                 leaving the context.
 
         Returns:
-            Name of the created file.
+            Path object of the created file.
 
         """
         if filename:
-            with open(filename, "rb") as f:
-                f.write(self.get(key))
+            filename = Path(filename).resolve()
+            filename.write_bytes(self.get(key))
         else:
             if prefix is None:
                 prefix = "oteapi-download-"
             with tempfile.NamedTemporaryFile(
                 prefix=prefix, suffix=suffix, dir=directory, delete=False
-            ) as f:
-                f.write(self.get(key))
-                filename = f.name
+            ) as handle:
+                handle.write(self.get(key))
+                filename = Path(handle.name).resolve()
 
         try:
             yield filename
         finally:
             if delete:
-                os.remove(filename)
+                filename.unlink()
 
     def evict(self, tag: str) -> None:
         """Remove all cache items with the given tag.
 
         Useful for cleaning up a session.
         """
-        asyncrun(self.dc.evict, tag)
+        asyncrun(self.datacache.evict, tag)
 
     def clear(self) -> None:
         """Remove all items from cache."""
-        asyncrun(self.dc.clear)
+        asyncrun(self.datacache.clear)

--- a/oteapi/interfaces/__init__.py
+++ b/oteapi/interfaces/__init__.py
@@ -11,7 +11,6 @@ from .iparsestrategy import IParseStrategy
 from .iresourcestrategy import IResourceStrategy
 from .itransformationstrategy import ITransformationStrategy
 
-
 __all__ = (
     "IDownloadStrategy",
     "IFilterStrategy",

--- a/oteapi/interfaces/idownloadstrategy.py
+++ b/oteapi/interfaces/idownloadstrategy.py
@@ -13,11 +13,11 @@ class IDownloadStrategy(Protocol):  # pylint: disable=R0903
 
     resource_config: ResourceConfig
 
-    def read(self, session: Optional[Dict[str, Any]] = None) -> Dict:
+    def read(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Dowload data from source"""
 
-    def get(self, session: Optional[Dict[str, Any]] = None) -> Dict:
+    def get(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Dowload data from source"""
 
-    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict:
+    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Initialize"""

--- a/oteapi/interfaces/idownloadstrategy.py
+++ b/oteapi/interfaces/idownloadstrategy.py
@@ -1,21 +1,26 @@
 """Download Strategy Interface"""
 from dataclasses import dataclass
-from typing import Any, Dict, Optional, Protocol
+from typing import TYPE_CHECKING, Protocol
 
-from oteapi.models.resourceconfig import ResourceConfig
+if TYPE_CHECKING:
+    from typing import Any, Dict, Optional
+
+    from oteapi.models.resourceconfig import ResourceConfig
 
 
 @dataclass  # type: ignore[misc]
 class IDownloadStrategy(Protocol):
     """Download Interfaces"""
 
-    resource_config: ResourceConfig
+    resource_config: "ResourceConfig"
 
-    def read(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def read(self, session: "Optional[Dict[str, Any]]" = None) -> "Dict[str, Any]":
         """Dowload data from source"""
 
-    def get(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def get(self, session: "Optional[Dict[str, Any]]" = None) -> "Dict[str, Any]":
         """Dowload data from source"""
 
-    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def initialize(
+        self, session: "Optional[Dict[str, Any]]" = None
+    ) -> "Dict[str, Any]":
         """Initialize"""

--- a/oteapi/interfaces/idownloadstrategy.py
+++ b/oteapi/interfaces/idownloadstrategy.py
@@ -1,15 +1,13 @@
-"""
-Download Strategy Interface
-"""
+"""Download Strategy Interface"""
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, Protocol
 
 from oteapi.models.resourceconfig import ResourceConfig
 
 
-@dataclass
-class IDownloadStrategy(Protocol):  # pylint: disable=R0903
-    """Data Storage Interfaces"""
+@dataclass  # type: ignore[misc]
+class IDownloadStrategy(Protocol):
+    """Download Interfaces"""
 
     resource_config: ResourceConfig
 

--- a/oteapi/interfaces/ifilterstrategy.py
+++ b/oteapi/interfaces/ifilterstrategy.py
@@ -1,18 +1,23 @@
 """Filter Strategy Interface"""
 from dataclasses import dataclass
-from typing import Any, Dict, Optional, Protocol
+from typing import TYPE_CHECKING, Protocol
 
-from oteapi.models.filterconfig import FilterConfig
+if TYPE_CHECKING:
+    from typing import Any, Dict, Optional
+
+    from oteapi.models.filterconfig import FilterConfig
 
 
 @dataclass  # type: ignore[misc]
 class IFilterStrategy(Protocol):
     """Filter Interface"""
 
-    filter_config: FilterConfig
+    filter_config: "FilterConfig"
 
-    def get(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def get(self, session: "Optional[Dict[str, Any]]" = None) -> "Dict[str, Any]":
         """Execute strategy and return a dictionary"""
 
-    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def initialize(
+        self, session: "Optional[Dict[str, Any]]" = None
+    ) -> "Dict[str, Any]":
         """Initialize strategy and return a dictionary"""

--- a/oteapi/interfaces/ifilterstrategy.py
+++ b/oteapi/interfaces/ifilterstrategy.py
@@ -1,16 +1,13 @@
-"""
-Resource Strategy Interface
-"""
-
+"""Filter Strategy Interface"""
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, Protocol
 
 from oteapi.models.filterconfig import FilterConfig
 
 
-@dataclass
+@dataclass  # type: ignore[misc]
 class IFilterStrategy(Protocol):
-    """Resource Interface"""
+    """Filter Interface"""
 
     filter_config: FilterConfig
 

--- a/oteapi/interfaces/ifilterstrategy.py
+++ b/oteapi/interfaces/ifilterstrategy.py
@@ -14,8 +14,8 @@ class IFilterStrategy(Protocol):
 
     filter_config: FilterConfig
 
-    def get(self, session: Optional[Dict[str, Any]] = None) -> Dict:
+    def get(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Execute strategy and return a dictionary"""
 
-    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict:
+    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Initialize strategy and return a dictionary"""

--- a/oteapi/interfaces/imappingstrategy.py
+++ b/oteapi/interfaces/imappingstrategy.py
@@ -1,19 +1,23 @@
 """Mapping Strategy Interface"""
-
 from dataclasses import dataclass
-from typing import Any, Dict, Optional, Protocol
+from typing import TYPE_CHECKING, Protocol
 
-from oteapi.models.mappingconfig import MappingConfig
+if TYPE_CHECKING:
+    from typing import Any, Dict, Optional
+
+    from oteapi.models.mappingconfig import MappingConfig
 
 
 @dataclass  # type: ignore[misc]
 class IMappingStrategy(Protocol):
     """Mapping Interface"""
 
-    mapping_config: MappingConfig
+    mapping_config: "MappingConfig"
 
-    def get(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def get(self, session: "Optional[Dict[str, Any]]" = None) -> "Dict[str, Any]":
         """Execute strategy and return a dictionary"""
 
-    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def initialize(
+        self, session: "Optional[Dict[str, Any]]" = None
+    ) -> "Dict[str, Any]":
         """Initialize strategy and return a dictionary"""

--- a/oteapi/interfaces/imappingstrategy.py
+++ b/oteapi/interfaces/imappingstrategy.py
@@ -1,6 +1,4 @@
-"""
-Mapping Strategy Interface
-"""
+"""Mapping Strategy Interface"""
 
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, Protocol
@@ -8,7 +6,7 @@ from typing import Any, Dict, Optional, Protocol
 from oteapi.models.mappingconfig import MappingConfig
 
 
-@dataclass
+@dataclass  # type: ignore[misc]
 class IMappingStrategy(Protocol):
     """Mapping Interface"""
 

--- a/oteapi/interfaces/imappingstrategy.py
+++ b/oteapi/interfaces/imappingstrategy.py
@@ -14,8 +14,8 @@ class IMappingStrategy(Protocol):
 
     mapping_config: MappingConfig
 
-    def get(self, session: Optional[Dict[str, Any]] = None) -> Dict:
+    def get(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Execute strategy and return a dictionary"""
 
-    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict:
+    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Initialize strategy and return a dictionary"""

--- a/oteapi/interfaces/iparsestrategy.py
+++ b/oteapi/interfaces/iparsestrategy.py
@@ -14,8 +14,8 @@ class IParseStrategy(Protocol):  # pylint: disable=R0903
 
     resource_config: ResourceConfig
 
-    def parse(self, session: Optional[Dict[str, Any]] = None) -> Dict:
+    def parse(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """run parser and return a dictionary"""
 
-    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict:
+    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Initialize"""

--- a/oteapi/interfaces/iparsestrategy.py
+++ b/oteapi/interfaces/iparsestrategy.py
@@ -1,18 +1,23 @@
 """Parse Strategy Interface"""
 from dataclasses import dataclass
-from typing import Any, Dict, Optional, Protocol
+from typing import TYPE_CHECKING, Protocol
 
-from oteapi.models.resourceconfig import ResourceConfig
+if TYPE_CHECKING:
+    from typing import Any, Dict, Optional
+
+    from oteapi.models.resourceconfig import ResourceConfig
 
 
 @dataclass  # type: ignore[misc]
 class IParseStrategy(Protocol):
     """Parse Interfaces"""
 
-    resource_config: ResourceConfig
+    resource_config: "ResourceConfig"
 
-    def parse(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def parse(self, session: "Optional[Dict[str, Any]]" = None) -> "Dict[str, Any]":
         """run parser and return a dictionary"""
 
-    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def initialize(
+        self, session: "Optional[Dict[str, Any]]" = None
+    ) -> "Dict[str, Any]":
         """Initialize"""

--- a/oteapi/interfaces/iparsestrategy.py
+++ b/oteapi/interfaces/iparsestrategy.py
@@ -1,16 +1,13 @@
-"""
-Data Storage Interface
-"""
-
+"""Parse Strategy Interface"""
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, Protocol
 
 from oteapi.models.resourceconfig import ResourceConfig
 
 
-@dataclass
-class IParseStrategy(Protocol):  # pylint: disable=R0903
-    """Data Storage Interfaces"""
+@dataclass  # type: ignore[misc]
+class IParseStrategy(Protocol):
+    """Parse Interfaces"""
 
     resource_config: ResourceConfig
 

--- a/oteapi/interfaces/iresourcestrategy.py
+++ b/oteapi/interfaces/iresourcestrategy.py
@@ -1,16 +1,13 @@
-"""
-Data Storage Interface
-"""
-
+"""Resource Strategy Interface"""
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, Protocol
 
 from oteapi.models.resourceconfig import ResourceConfig
 
 
-@dataclass
-class IResourceStrategy(Protocol):  # pylint: disable=R0903
-    """Resource  Interfaces"""
+@dataclass  # type: ignore[misc]
+class IResourceStrategy(Protocol):
+    """Resource Interfaces"""
 
     resource_config: ResourceConfig
 

--- a/oteapi/interfaces/iresourcestrategy.py
+++ b/oteapi/interfaces/iresourcestrategy.py
@@ -14,8 +14,8 @@ class IResourceStrategy(Protocol):  # pylint: disable=R0903
 
     resource_config: ResourceConfig
 
-    def get(self, session: Optional[Dict[str, Any]] = None) -> Dict:
+    def get(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Run get-method and return a dictionary"""
 
-    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict:
+    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Initialize"""

--- a/oteapi/interfaces/iresourcestrategy.py
+++ b/oteapi/interfaces/iresourcestrategy.py
@@ -1,18 +1,23 @@
 """Resource Strategy Interface"""
 from dataclasses import dataclass
-from typing import Any, Dict, Optional, Protocol
+from typing import TYPE_CHECKING, Protocol
 
-from oteapi.models.resourceconfig import ResourceConfig
+if TYPE_CHECKING:
+    from typing import Any, Dict, Optional
+
+    from oteapi.models.resourceconfig import ResourceConfig
 
 
 @dataclass  # type: ignore[misc]
 class IResourceStrategy(Protocol):
     """Resource Interfaces"""
 
-    resource_config: ResourceConfig
+    resource_config: "ResourceConfig"
 
-    def get(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def get(self, session: "Optional[Dict[str, Any]]" = None) -> "Dict[str, Any]":
         """Run get-method and return a dictionary"""
 
-    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def initialize(
+        self, session: "Optional[Dict[str, Any]]" = None
+    ) -> "Dict[str, Any]":
         """Initialize"""

--- a/oteapi/interfaces/itransformationstrategy.py
+++ b/oteapi/interfaces/itransformationstrategy.py
@@ -1,5 +1,4 @@
-""" Tranformation Strategy Interface
-"""
+"""Tranformation Strategy Interface"""
 
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, Protocol
@@ -10,9 +9,9 @@ from oteapi.models.transformationconfig import (
 )
 
 
-@dataclass
-class ITransformationStrategy(Protocol):  # pylint: disable=R0903
-    """Tranformation Strategy Interfaces"""
+@dataclass  # type: ignore[misc]
+class ITransformationStrategy(Protocol):
+    """Tranformation Interfaces"""
 
     transformation_config: TransformationConfig
 

--- a/oteapi/interfaces/itransformationstrategy.py
+++ b/oteapi/interfaces/itransformationstrategy.py
@@ -16,14 +16,14 @@ class ITransformationStrategy(Protocol):  # pylint: disable=R0903
 
     transformation_config: TransformationConfig
 
-    def run(self, session: Optional[Dict[str, Any]] = None) -> Dict:
+    def run(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Run a job, return jobid"""
 
     def status(self, task_id: str) -> TransformationStatus:
         """Get job status"""
 
-    def get(self, session: Optional[Dict[str, Any]] = None) -> Dict:
+    def get(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """get transformation"""
 
-    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict:
+    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """initialize transformation"""

--- a/oteapi/interfaces/itransformationstrategy.py
+++ b/oteapi/interfaces/itransformationstrategy.py
@@ -1,28 +1,30 @@
 """Tranformation Strategy Interface"""
 
 from dataclasses import dataclass
-from typing import Any, Dict, Optional, Protocol
+from typing import TYPE_CHECKING, Protocol
 
-from oteapi.models.transformationconfig import (
-    TransformationConfig,
-    TransformationStatus,
-)
+if TYPE_CHECKING:
+    from typing import Any, Dict, Optional
+
+    from oteapi.models import TransformationConfig, TransformationStatus
 
 
 @dataclass  # type: ignore[misc]
 class ITransformationStrategy(Protocol):
     """Tranformation Interfaces"""
 
-    transformation_config: TransformationConfig
+    transformation_config: "TransformationConfig"
 
-    def run(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def run(self, session: "Optional[Dict[str, Any]]" = None) -> "Dict[str, Any]":
         """Run a job, return jobid"""
 
-    def status(self, task_id: str) -> TransformationStatus:
+    def status(self, task_id: str) -> "TransformationStatus":
         """Get job status"""
 
-    def get(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def get(self, session: "Optional[Dict[str, Any]]" = None) -> "Dict[str, Any]":
         """get transformation"""
 
-    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def initialize(
+        self, session: "Optional[Dict[str, Any]]" = None
+    ) -> "Dict[str, Any]":
         """initialize transformation"""

--- a/oteapi/models/__init__.py
+++ b/oteapi/models/__init__.py
@@ -6,7 +6,7 @@ from .downloadconfig import DownloadConfig
 from .filterconfig import FilterConfig
 from .mappingconfig import MappingConfig
 from .resourceconfig import ResourceConfig
-from .transformationconfig import TransformationConfig
+from .transformationconfig import TransformationConfig, TransformationStatus
 
 __all__ = (
     "DownloadConfig",
@@ -14,4 +14,5 @@ __all__ = (
     "MappingConfig",
     "ResourceConfig",
     "TransformationConfig",
+    "TransformationStatus",
 )

--- a/oteapi/models/__init__.py
+++ b/oteapi/models/__init__.py
@@ -8,7 +8,6 @@ from .mappingconfig import MappingConfig
 from .resourceconfig import ResourceConfig
 from .transformationconfig import TransformationConfig
 
-
 __all__ = (
     "DownloadConfig",
     "FilterConfig",

--- a/oteapi/models/mappingconfig.py
+++ b/oteapi/models/mappingconfig.py
@@ -1,7 +1,4 @@
-"""
-Pydantic Mapping Data Model
-"""
-
+"""Pydantic Mapping Data Model"""
 from typing import Dict, List, Optional
 
 from pydantic import BaseModel, Field, conlist
@@ -22,7 +19,7 @@ class MappingConfig(BaseModel):
             "given as localvalue/IRI-expansion-pairs"
         ),
     )
-    triples: Optional[List[SemanticTriple]] = Field(
+    triples: Optional[List[SemanticTriple]] = Field(  # type: ignore[valid-type]
         None,
         description="List of semantic triples given as (subject, predicate, object).",
     )

--- a/oteapi/models/resourceconfig.py
+++ b/oteapi/models/resourceconfig.py
@@ -1,7 +1,4 @@
-"""
-Pydantic ResourceConfig Data Model
-"""
-
+"""Pydantic ResourceConfig Data Model"""
 from typing import Any, Dict, Optional
 
 from pydantic import AnyUrl, BaseModel, Field, root_validator

--- a/oteapi/models/transformationconfig.py
+++ b/oteapi/models/transformationconfig.py
@@ -1,6 +1,4 @@
-"""
-TransformationConfig data model definition
-"""
+"""TransformationConfig data model definition"""
 from datetime import datetime
 from enum import Enum
 from typing import Dict, List, Optional

--- a/oteapi/plugins/__init__.py
+++ b/oteapi/plugins/__init__.py
@@ -1,4 +1,5 @@
 """`oteapi.plugins` module."""
+from .factories import StrategyFactory
 from .plugins import load_plugins
 
-__all__ = ("load_plugins",)
+__all__ = ("StrategyFactory", "load_plugins")

--- a/oteapi/plugins/__init__.py
+++ b/oteapi/plugins/__init__.py
@@ -1,5 +1,4 @@
 """`oteapi.plugins` module."""
 from .plugins import load_plugins
 
-
 __all__ = ("load_plugins",)

--- a/oteapi/plugins/factories.py
+++ b/oteapi/plugins/factories.py
@@ -4,7 +4,7 @@ Factory class for registering and creating strategy instances
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from typing import Tuple, TypeVar
+    from typing import Any, Callable, Dict, Tuple, Union
     from uuid import UUID
 
     from pydantic import AnyUrl, BaseModel
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
         TransformationConfig,
     )
 
-    ValueType = TypeVar("ValueType", int, str, AnyUrl, UUID)
+    ValueType = Union[int, str, AnyUrl, UUID]
 
 
 class StrategyFactory:
@@ -33,7 +33,7 @@ class StrategyFactory:
     Decorator based Factory class
     """
 
-    strategy_create_func = {}
+    strategy_create_func: "Dict[Tuple[str, ValueType], Callable[[Any], Any]]" = {}
 
     @classmethod
     def make_strategy(
@@ -53,7 +53,7 @@ class StrategyFactory:
     def register(cls, *args: "Tuple[str, ValueType]"):
         """Register a strategy.
 
-        The identifyer for the strategy is defined by a set of key-value tuple pairs.
+        The identifier for the strategy is defined by a set of key-value tuple pairs.
         """
 
         def decorator(strategy_class):
@@ -68,9 +68,9 @@ class StrategyFactory:
         return decorator
 
     @classmethod
-    def unregister(cls, *kwargs: "Tuple[str, ValueType]") -> None:
+    def unregister(cls, *args: "Tuple[str, ValueType]") -> None:
         """Unregister a strategy"""
-        for index in kwargs:
+        for index in args:
             cls.strategy_create_func.pop(index, None)
 
 

--- a/oteapi/plugins/factories.py
+++ b/oteapi/plugins/factories.py
@@ -9,13 +9,6 @@ if TYPE_CHECKING:
 
     from pydantic import AnyUrl, BaseModel
 
-    from oteapi.models import (
-        DownloadConfig,
-        FilterConfig,
-        MappingConfig,
-        ResourceConfig,
-        TransformationConfig,
-    )
     from oteapi.interfaces import (
         IDownloadStrategy,
         IFilterStrategy,
@@ -23,6 +16,13 @@ if TYPE_CHECKING:
         IParseStrategy,
         IResourceStrategy,
         ITransformationStrategy,
+    )
+    from oteapi.models import (
+        DownloadConfig,
+        FilterConfig,
+        MappingConfig,
+        ResourceConfig,
+        TransformationConfig,
     )
 
     ValueType = TypeVar("ValueType", int, str, AnyUrl, UUID)
@@ -36,7 +36,9 @@ class StrategyFactory:
     strategy_create_func = {}
 
     @classmethod
-    def make_strategy(cls, model: "BaseModel", field: str = None, index=None) -> "BaseModel":
+    def make_strategy(
+        cls, model: "BaseModel", field: str = None, index=None
+    ) -> "BaseModel":
         """Instantiate a strategy in a context class"""
 
         try:

--- a/oteapi/plugins/plugins.py
+++ b/oteapi/plugins/plugins.py
@@ -4,10 +4,11 @@ from importlib.metadata import entry_points
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from types import ModuleType
     from typing import List, Set
 
 
-class PluginInterface:  # pylint: disable=R0903
+class PluginInterface:
     """Call the plugin to be initialized"""
 
     @staticmethod
@@ -15,9 +16,9 @@ class PluginInterface:  # pylint: disable=R0903
         """Initialize the plugin"""
 
 
-def import_module(name: str) -> PluginInterface:
+def import_module(name: str) -> "ModuleType":
     """import modules"""
-    return importlib.import_module(name)  # type: ignore
+    return importlib.import_module(name)
 
 
 def get_all_entry_points() -> "List[str]":

--- a/oteapi/strategies/download/file.py
+++ b/oteapi/strategies/download/file.py
@@ -2,13 +2,17 @@
 # pylint: disable=unused-argument
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING, Optional
 
 from pydantic import BaseModel, Extra, Field
 
-from oteapi.datacache.datacache import DataCache
-from oteapi.models.resourceconfig import ResourceConfig
-from oteapi.plugins.factories import StrategyFactory
+from oteapi.datacache import DataCache
+from oteapi.plugins import StrategyFactory
+
+if TYPE_CHECKING:
+    from typing import Any, Dict
+
+    from oteapi.models import ResourceConfig
 
 
 class FileConfig(BaseModel):
@@ -17,7 +21,7 @@ class FileConfig(BaseModel):
     text: bool = Field(
         False, description="Whether the file should be opened in text mode."
     )
-    encoding: str = Field(
+    encoding: Optional[str] = Field(
         None,
         description=(
             "Encoding used when opening the file. Default is platform dependent."
@@ -32,13 +36,15 @@ class FileConfig(BaseModel):
 class FileStrategy:
     """Strategy for retrieving data via local file."""
 
-    resource_config: ResourceConfig
+    resource_config: "ResourceConfig"
 
-    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def initialize(
+        self, session: "Optional[Dict[str, Any]]" = None
+    ) -> "Dict[str, Any]":
         """Initialize"""
         return {}
 
-    def get(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def get(self, session: "Optional[Dict[str, Any]]" = None) -> "Dict[str, Any]":
         """Read local file."""
         if (
             self.resource_config.downloadUrl is None

--- a/oteapi/strategies/download/file.py
+++ b/oteapi/strategies/download/file.py
@@ -40,8 +40,14 @@ class FileStrategy:
 
     def get(self, session: Optional[Dict[str, Any]] = None) -> Dict:
         """Read local file."""
-        assert self.resource_config.downloadUrl
-        assert self.resource_config.downloadUrl.scheme == "file"
+        if (
+            self.resource_config.downloadUrl is None
+            or self.resource_config.downloadUrl.scheme != "file"
+        ):
+            raise ValueError(
+                "Expected 'downloadUrl' to have scheme 'file' in the configuration."
+            )
+
         filename = self.resource_config.downloadUrl.host
 
         cache = DataCache(self.resource_config.configuration)

--- a/oteapi/strategies/download/https.py
+++ b/oteapi/strategies/download/https.py
@@ -27,6 +27,8 @@ class HTTPSStrategy:
         if cache.config.accessKey and cache.config.accessKey in cache:
             key = cache.config.accessKey
         else:
+            if not self.resource_config.downloadUrl:
+                raise ValueError("downloadUrl not defined in configuration.")
             req = requests.get(self.resource_config.downloadUrl, allow_redirects=True)
             key = cache.add(req.content)
 

--- a/oteapi/strategies/download/https.py
+++ b/oteapi/strategies/download/https.py
@@ -1,13 +1,17 @@
 """Download strategy class for http/https"""
 # pylint: disable=unused-argument
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING
 
 import requests
 
-from oteapi.datacache.datacache import DataCache
-from oteapi.models.resourceconfig import ResourceConfig
-from oteapi.plugins.factories import StrategyFactory
+from oteapi.datacache import DataCache
+from oteapi.plugins import StrategyFactory
+
+if TYPE_CHECKING:
+    from typing import Any, Dict, Optional
+
+    from oteapi.models import ResourceConfig
 
 
 @dataclass
@@ -15,13 +19,15 @@ from oteapi.plugins.factories import StrategyFactory
 class HTTPSStrategy:
     """Strategy for retrieving data via http."""
 
-    resource_config: ResourceConfig
+    resource_config: "ResourceConfig"
 
-    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def initialize(
+        self, session: "Optional[Dict[str, Any]]" = None
+    ) -> "Dict[str, Any]":
         """Initialize"""
         return {}
 
-    def get(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def get(self, session: "Optional[Dict[str, Any]]" = None) -> "Dict[str, Any]":
         """Download via http/https and store on local cache."""
         cache = DataCache(self.resource_config.configuration)
         if cache.config.accessKey and cache.config.accessKey in cache:

--- a/oteapi/strategies/download/https.py
+++ b/oteapi/strategies/download/https.py
@@ -1,4 +1,5 @@
 """Download strategy class for http/https"""
+# pylint: disable=unused-argument
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
@@ -16,13 +17,11 @@ class HTTPSStrategy:
 
     resource_config: ResourceConfig
 
-    def initialize(
-        self, session: Optional[Dict[str, Any]] = None  # pylint: disable=W0613
-    ) -> Dict:
+    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Initialize"""
         return {}
 
-    def get(self, session: Optional[Dict[str, Any]] = None) -> Dict:
+    def get(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Download via http/https and store on local cache."""
         cache = DataCache(self.resource_config.configuration)
         if cache.config.accessKey and cache.config.accessKey in cache:

--- a/oteapi/strategies/download/sftp.py
+++ b/oteapi/strategies/download/sftp.py
@@ -3,13 +3,17 @@
 from dataclasses import dataclass
 from pathlib import Path
 from tempfile import NamedTemporaryFile
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING
 
 import pysftp
 
-from oteapi.datacache.datacache import DataCache
-from oteapi.models.resourceconfig import ResourceConfig
-from oteapi.plugins.factories import StrategyFactory
+from oteapi.datacache import DataCache
+from oteapi.plugins import StrategyFactory
+
+if TYPE_CHECKING:
+    from typing import Any, Dict, Optional
+
+    from oteapi.models import ResourceConfig
 
 
 @dataclass
@@ -17,13 +21,15 @@ from oteapi.plugins.factories import StrategyFactory
 class SFTPStrategy:
     """Strategy for retrieving data via sftp."""
 
-    resource_config: ResourceConfig
+    resource_config: "ResourceConfig"
 
-    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def initialize(
+        self, session: "Optional[Dict[str, Any]]" = None
+    ) -> "Dict[str, Any]":
         """Initialize"""
         return {}
 
-    def get(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def get(self, session: "Optional[Dict[str, Any]]" = None) -> "Dict[str, Any]":
         """Download via sftp"""
         cache = DataCache(self.resource_config.configuration)
         if cache.config.accessKey and cache.config.accessKey in cache:

--- a/oteapi/strategies/download/sftp.py
+++ b/oteapi/strategies/download/sftp.py
@@ -33,6 +33,9 @@ class SFTPStrategy:
             cnopts = pysftp.CnOpts()
             cnopts.hostkeys = None
 
+            if not self.resource_config.accessUrl:
+                raise ValueError("accessUrl is not defined in configuration.")
+
             # open connection and store data locally
             with pysftp.Connection(
                 host=self.resource_config.accessUrl.host,

--- a/oteapi/strategies/filter/crop_filter.py
+++ b/oteapi/strategies/filter/crop_filter.py
@@ -25,5 +25,9 @@ class CropFilter:
 
     def get(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Execute strategy and return a dictionary"""
-        cropData = CropDataModel(**self.filter_config.configuration)
+        cropData = (
+            CropDataModel(**self.filter_config.configuration)
+            if self.filter_config.configuration
+            else CropDataModel()
+        )
         return {"imagecrop": cropData.crop}

--- a/oteapi/strategies/filter/crop_filter.py
+++ b/oteapi/strategies/filter/crop_filter.py
@@ -1,12 +1,16 @@
 """Demo-filter strategy"""
 # pylint: disable=unused-argument
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, List
 
 from pydantic import BaseModel
 
-from oteapi.models.filterconfig import FilterConfig
-from oteapi.plugins.factories import StrategyFactory
+from oteapi.plugins import StrategyFactory
+
+if TYPE_CHECKING:
+    from typing import Any, Dict, Optional
+
+    from oteapi.models import FilterConfig
 
 
 class CropDataModel(BaseModel):
@@ -17,13 +21,15 @@ class CropDataModel(BaseModel):
 @StrategyFactory.register(("filterType", "filter/crop"))
 class CropFilter:
 
-    filter_config: FilterConfig
+    filter_config: "FilterConfig"
 
-    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def initialize(
+        self, session: "Optional[Dict[str, Any]]" = None
+    ) -> "Dict[str, Any]":
         """Initialize strategy and return a dictionary"""
         return {"result": "collectionid"}
 
-    def get(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def get(self, session: "Optional[Dict[str, Any]]" = None) -> "Dict[str, Any]":
         """Execute strategy and return a dictionary"""
         cropData = (
             CropDataModel(**self.filter_config.configuration)

--- a/oteapi/strategies/filter/crop_filter.py
+++ b/oteapi/strategies/filter/crop_filter.py
@@ -1,4 +1,5 @@
 """Demo-filter strategy"""
+# pylint: disable=unused-argument
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
@@ -18,16 +19,11 @@ class CropFilter:
 
     filter_config: FilterConfig
 
-    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict:
+    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Initialize strategy and return a dictionary"""
+        return {"result": "collectionid"}
 
-        # TODO: Add logic
-        return dict(result="collectionid")
-
-    def get(self, session: Optional[Dict[str, Any]] = None) -> Dict:
+    def get(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Execute strategy and return a dictionary"""
-
         cropData = CropDataModel(**self.filter_config.configuration)
-        retobj = dict(imagecrop=cropData.crop)
-
-        return retobj
+        return {"imagecrop": cropData.crop}

--- a/oteapi/strategies/filter/sql_query_filter.py
+++ b/oteapi/strategies/filter/sql_query_filter.py
@@ -1,4 +1,5 @@
 """SQL query filter strategy"""
+# pylint: disable=unused-argument
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
@@ -18,15 +19,11 @@ class QFilter:
 
     filter_config: FilterConfig
 
-    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict:
+    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Initialize strategy and return a dictionary"""
-        if session is None:
-            raise ValueError("Missing session")
         queryData = SqlQueryDataModel(**{"query": self.filter_config.query})
-        retobj = dict(sqlquery=queryData.query)
+        return {"sqlquery": queryData.query}
 
-        return retobj
-
-    def get(self, session: Optional[Dict[str, Any]] = None) -> Dict:
+    def get(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Execute strategy and return a dictionary"""
-        return dict()
+        return {}

--- a/oteapi/strategies/filter/sql_query_filter.py
+++ b/oteapi/strategies/filter/sql_query_filter.py
@@ -1,12 +1,16 @@
 """SQL query filter strategy"""
 # pylint: disable=unused-argument
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING
 
 from pydantic import BaseModel
 
-from oteapi.models.filterconfig import FilterConfig
-from oteapi.plugins.factories import StrategyFactory
+from oteapi.plugins import StrategyFactory
+
+if TYPE_CHECKING:
+    from typing import Any, Dict, Optional
+
+    from oteapi.models import FilterConfig
 
 
 class SqlQueryDataModel(BaseModel):
@@ -15,15 +19,17 @@ class SqlQueryDataModel(BaseModel):
 
 @dataclass
 @StrategyFactory.register(("filterType", "filter/sql"))
-class QFilter:
+class SQLQueryFilter:
 
-    filter_config: FilterConfig
+    filter_config: "FilterConfig"
 
-    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def initialize(
+        self, session: "Optional[Dict[str, Any]]" = None
+    ) -> "Dict[str, Any]":
         """Initialize strategy and return a dictionary"""
         queryData = SqlQueryDataModel(**{"query": self.filter_config.query})
         return {"sqlquery": queryData.query}
 
-    def get(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def get(self, session: "Optional[Dict[str, Any]]" = None) -> "Dict[str, Any]":
         """Execute strategy and return a dictionary"""
         return {}

--- a/oteapi/strategies/parse/application_vnd_sqlite.py
+++ b/oteapi/strategies/parse/application_vnd_sqlite.py
@@ -1,4 +1,5 @@
-""" Strategy class for application/vnd.sqlite3 """
+"""Strategy class for application/vnd.sqlite3."""
+# pylint: disable=unused-argument
 import sqlite3
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
@@ -29,22 +30,17 @@ class SqliteParseStrategy:
 
     resource_config: ResourceConfig
 
-    def parse(
-        self, session: Optional[Dict[str, Any]] = None  # pylint: disable=W0613
-    ) -> Dict:
-
+    def parse(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         if session is None:
             raise ValueError("Missing session")
+
         if "sqlquery" in session:
             cn = create_connection(session["filename"])
             cur = cn.cursor()
             rows = cur.execute(session["sqlquery"]).fetchall()
-            return dict(result=rows)
-        else:
-            return dict(result="No query given")
+            return {"result": rows}
+        return {"result": "No query given"}
 
-    def initialize(
-        self, session: Optional[Dict[str, Any]] = None  # pylint: disable=W0613
-    ) -> Dict:
+    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Initialize"""
-        return dict()
+        return {}

--- a/oteapi/strategies/parse/application_vnd_sqlite.py
+++ b/oteapi/strategies/parse/application_vnd_sqlite.py
@@ -1,6 +1,6 @@
 """ Strategy class for application/vnd.sqlite3 """
-from dataclasses import dataclass
 import sqlite3
+from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
 from oteapi.models.resourceconfig import ResourceConfig

--- a/oteapi/strategies/parse/application_vnd_sqlite.py
+++ b/oteapi/strategies/parse/application_vnd_sqlite.py
@@ -2,10 +2,14 @@
 # pylint: disable=unused-argument
 import sqlite3
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING
 
-from oteapi.models.resourceconfig import ResourceConfig
-from oteapi.plugins.factories import StrategyFactory
+from oteapi.plugins import StrategyFactory
+
+if TYPE_CHECKING:
+    from typing import Any, Dict, Optional
+
+    from oteapi.models import ResourceConfig
 
 
 def create_connection(db_file):
@@ -28,9 +32,9 @@ def create_connection(db_file):
 @StrategyFactory.register(("mediaType", "application/vnd.sqlite3"))
 class SqliteParseStrategy:
 
-    resource_config: ResourceConfig
+    resource_config: "ResourceConfig"
 
-    def parse(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def parse(self, session: "Optional[Dict[str, Any]]" = None) -> "Dict[str, Any]":
         if session is None:
             raise ValueError("Missing session")
 
@@ -41,6 +45,8 @@ class SqliteParseStrategy:
             return {"result": rows}
         return {"result": "No query given"}
 
-    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def initialize(
+        self, session: "Optional[Dict[str, Any]]" = None
+    ) -> "Dict[str, Any]":
         """Initialize"""
         return {}

--- a/oteapi/strategies/parse/excel_xlsx.py
+++ b/oteapi/strategies/parse/excel_xlsx.py
@@ -1,16 +1,21 @@
 """Strategy class for workbook/xlsx."""
 # pylint: disable=unused-argument
 from dataclasses import dataclass
-from typing import Any, Dict, Iterable, List, Optional, Union
+from typing import TYPE_CHECKING, List, Optional, Union
 
 from openpyxl import load_workbook
 from openpyxl.utils import column_index_from_string, get_column_letter
-from openpyxl.worksheet.worksheet import Worksheet
 from pydantic import BaseModel, Extra
 
-from oteapi.datacache.datacache import DataCache
-from oteapi.models.resourceconfig import ResourceConfig
+from oteapi.datacache import DataCache
 from oteapi.plugins.factories import StrategyFactory, create_download_strategy
+
+if TYPE_CHECKING:
+    from typing import Any, Dict, Iterable
+
+    from openpyxl.worksheet.worksheet import Worksheet
+
+    from oteapi.models import ResourceConfig
 
 
 class XLSXParseDataModel(BaseModel):
@@ -44,7 +49,7 @@ class XLSXParseDataModel(BaseModel):
     new_header: Optional[List[str]] = None
 
 
-def set_model_defaults(model: XLSXParseDataModel, worksheet: Worksheet) -> None:
+def set_model_defaults(model: XLSXParseDataModel, worksheet: "Worksheet") -> None:
     """Update datamodel `model` with default values obtained from `worksheet`."""
     if model.row_from is None:
         if model.header:
@@ -71,8 +76,8 @@ def set_model_defaults(model: XLSXParseDataModel, worksheet: Worksheet) -> None:
 
 
 def get_column_indices(
-    model: XLSXParseDataModel, worksheet: Worksheet
-) -> Iterable[int]:
+    model: XLSXParseDataModel, worksheet: "Worksheet"
+) -> "Iterable[int]":
     """Helper function returning a list of column indices."""
     if not isinstance(model.col_from, int) or not isinstance(model.col_to, int):
         raise TypeError("Expected `model.col_from` and `model.col_to` to be integers.")
@@ -92,13 +97,15 @@ def get_column_indices(
 )
 class XLSXParseStrategy:
 
-    resource_config: ResourceConfig
+    resource_config: "ResourceConfig"
 
-    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def initialize(
+        self, session: "Optional[Dict[str, Any]]" = None
+    ) -> "Dict[str, Any]":
         """Initialize"""
         return {}
 
-    def parse(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def parse(self, session: "Optional[Dict[str, Any]]" = None) -> "Dict[str, Any]":
         """Parses selected region of an excel file.
 
         Returns a dict with column-name/column-value pairs. The values are lists.

--- a/oteapi/strategies/parse/excel_xlsx.py
+++ b/oteapi/strategies/parse/excel_xlsx.py
@@ -1,4 +1,5 @@
-""" Strategy class for workbook/xlsx """
+"""Strategy class for workbook/xlsx."""
+# pylint: disable=unused-argument
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Union
 
@@ -43,7 +44,7 @@ class XLSXParseDataModel(BaseModel):
     new_header: List[str] = None
 
 
-def set_model_defaults(model: XLSXParseDataModel, worksheet: Worksheet):
+def set_model_defaults(model: XLSXParseDataModel, worksheet: Worksheet) -> None:
     """Update datamodel `model` with default values obtained from `worksheet`."""
     if model.row_from is None:
         if model.header:
@@ -76,10 +77,8 @@ def get_column_indices(model: XLSXParseDataModel, worksheet: Worksheet) -> List[
             worksheet.cell(model.header_row, col).value: col
             for col in range(model.col_from, model.col_to + 1)
         }
-        indices = [header_dict[h] for h in model.header]
-    else:
-        indices = range(model.col_from, model.col_to + 1)
-    return indices
+        return [header_dict[h] for h in model.header]
+    return range(model.col_from, model.col_to + 1)
 
 
 @dataclass
@@ -90,17 +89,14 @@ class XLSXParseStrategy:
 
     resource_config: ResourceConfig
 
-    def initialize(
-        self, session: Optional[Dict[str, Any]] = None  # pylint: disable=W0613
-    ) -> Dict:
+    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Initialize"""
         return {}
 
-    def parse(self, session: Optional[Dict[str, Any]] = None) -> Dict:
+    def parse(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Parses selected region of an excel file.
 
-        Returns a dict with column-name/column-value pairs.  The values are
-        lists.
+        Returns a dict with column-name/column-value pairs. The values are lists.
         """
         model = XLSXParseDataModel(
             **self.resource_config.configuration, extra=Extra.ignore

--- a/oteapi/strategies/parse/image_jpeg.py
+++ b/oteapi/strategies/parse/image_jpeg.py
@@ -1,12 +1,16 @@
 """Strategy class for image/jpg."""
 # pylint: disable=unused-argument
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING
 
 from PIL import Image
 
-from oteapi.models.resourceconfig import ResourceConfig
-from oteapi.plugins.factories import StrategyFactory
+from oteapi.plugins import StrategyFactory
+
+if TYPE_CHECKING:
+    from typing import Any, Dict, Optional
+
+    from oteapi.models import ResourceConfig
 
 
 @dataclass
@@ -21,7 +25,7 @@ from oteapi.plugins.factories import StrategyFactory
 )
 class ImageDataParseStrategy:
 
-    resource_config: ResourceConfig
+    resource_config: "ResourceConfig"
 
     def __post_init__(self):
         self.localpath = "/ote-data"
@@ -31,11 +35,13 @@ class ImageDataParseStrategy:
         else:
             self.conf = {}
 
-    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def initialize(
+        self, session: "Optional[Dict[str, Any]]" = None
+    ) -> "Dict[str, Any]":
         """Initialize"""
         return {}
 
-    def parse(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def parse(self, session: "Optional[Dict[str, Any]]" = None) -> "Dict[str, Any]":
         if session is not None:
             self.conf.update(session)
         parsedOutput = {}

--- a/oteapi/strategies/parse/image_jpeg.py
+++ b/oteapi/strategies/parse/image_jpeg.py
@@ -1,5 +1,5 @@
-# pylint: disable=  W0613
-""" Strategy class for image/jpg """
+"""Strategy class for image/jpg."""
+# pylint: disable=unused-argument
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
@@ -31,11 +31,11 @@ class ImageDataParseStrategy:
         else:
             self.conf = {}
 
-    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict:
+    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Initialize"""
-        return dict()
+        return {}
 
-    def parse(self, session: Optional[Dict[str, Any]] = None) -> Dict:
+    def parse(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         if session is not None:
             self.conf.update(session)
         parsedOutput = {}

--- a/oteapi/strategies/parse/text_csv.py
+++ b/oteapi/strategies/parse/text_csv.py
@@ -1,4 +1,5 @@
-""" Strategy class for text/csv """
+"""Strategy class for text/csv."""
+# pylint: disable=unused-argument
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
@@ -12,14 +13,10 @@ class CSVParseStrategy:
 
     resource_config: ResourceConfig
 
-    def parse(
-        self, session: Optional[Dict[str, Any]] = None  # pylint: disable=W0613
-    ) -> Dict:
+    def parse(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         print("CSV in action!")
         return {}
 
-    def initialize(
-        self, session: Optional[Dict[str, Any]] = None  # pylint: disable=W0613
-    ) -> Dict:
+    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Initialize"""
-        return dict()
+        return {}

--- a/oteapi/strategies/parse/text_csv.py
+++ b/oteapi/strategies/parse/text_csv.py
@@ -1,22 +1,28 @@
 """Strategy class for text/csv."""
 # pylint: disable=unused-argument
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING
 
-from oteapi.models.resourceconfig import ResourceConfig
-from oteapi.plugins.factories import StrategyFactory
+from oteapi.plugins import StrategyFactory
+
+if TYPE_CHECKING:
+    from typing import Any, Dict, Optional
+
+    from oteapi.models import ResourceConfig
 
 
 @dataclass
 @StrategyFactory.register(("mediaType", "text/csv"))
 class CSVParseStrategy:
 
-    resource_config: ResourceConfig
+    resource_config: "ResourceConfig"
 
-    def parse(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def parse(self, session: "Optional[Dict[str, Any]]" = None) -> "Dict[str, Any]":
         print("CSV in action!")
         return {}
 
-    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def initialize(
+        self, session: "Optional[Dict[str, Any]]" = None
+    ) -> "Dict[str, Any]":
         """Initialize"""
         return {}

--- a/oteapi/strategies/parse/text_json.py
+++ b/oteapi/strategies/parse/text_json.py
@@ -1,4 +1,5 @@
-""" Strategy class for text/json """
+"""Strategy class for text/json."""
+# pylint: disable=unused-argument
 import json
 from dataclasses import dataclass
 from typing import Any, Dict, Optional
@@ -14,15 +15,11 @@ class JSONDataParseStrategy:
 
     resource_config: ResourceConfig
 
-    def initialize(
-        self, session: Optional[Dict[str, Any]] = None  # pylint: disable=W0613
-    ) -> Dict:
+    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Initialize"""
         return {}
 
-    def parse(
-        self, session: Optional[Dict[str, Any]] = None  # pylint: disable=W0613
-    ) -> Dict:
+    def parse(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Parse json."""
         downloader = create_download_strategy(self.resource_config)
         output = downloader.get()
@@ -31,5 +28,4 @@ class JSONDataParseStrategy:
 
         if isinstance(content, dict):
             return content
-        else:
-            return json.loads(content)
+        return json.loads(content)

--- a/oteapi/strategies/parse/text_json.py
+++ b/oteapi/strategies/parse/text_json.py
@@ -2,24 +2,30 @@
 # pylint: disable=unused-argument
 import json
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import TYPE_CHECKING
 
-from oteapi.datacache.datacache import DataCache
-from oteapi.models.resourceconfig import ResourceConfig
+from oteapi.datacache import DataCache
 from oteapi.plugins.factories import StrategyFactory, create_download_strategy
+
+if TYPE_CHECKING:
+    from typing import Any, Dict, Optional
+
+    from oteapi.models import ResourceConfig
 
 
 @dataclass
 @StrategyFactory.register(("mediaType", "text/json"))
 class JSONDataParseStrategy:
 
-    resource_config: ResourceConfig
+    resource_config: "ResourceConfig"
 
-    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def initialize(
+        self, session: "Optional[Dict[str, Any]]" = None
+    ) -> "Dict[str, Any]":
         """Initialize"""
         return {}
 
-    def parse(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def parse(self, session: "Optional[Dict[str, Any]]" = None) -> "Dict[str, Any]":
         """Parse json."""
         downloader = create_download_strategy(self.resource_config)
         output = downloader.get()

--- a/oteapi/strategies/parse/text_json.py
+++ b/oteapi/strategies/parse/text_json.py
@@ -1,6 +1,6 @@
 """ Strategy class for text/json """
-from dataclasses import dataclass
 import json
+from dataclasses import dataclass
 from typing import Any, Dict, Optional
 
 from oteapi.datacache.datacache import DataCache

--- a/oteapi/strategies/transformation/celery_remote.py
+++ b/oteapi/strategies/transformation/celery_remote.py
@@ -1,4 +1,5 @@
-"""Transformation Plugin that use the Celery framework to call remote workers"""
+"""Transformation Plugin that uses the Celery framework to call remote workers."""
+# pylint: disable=unused-argument
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
@@ -29,28 +30,25 @@ class CeleryRemoteStrategy:
 
     transformation_config: TransformationConfig
 
-    def run(self, session_id: Optional[str] = None) -> Dict:
+    def run(self, session_id: Optional[str] = None) -> Dict[str, Any]:
         """Run a job, return a jobid"""
-
         config = self.transformation_config.configuration
         celeryConfig = CeleryConfig(**config)
         result = app.send_task(
             celeryConfig.taskName, celeryConfig.args, kwargs=session_id
         )
-        return dict(result=result.task_id)
+        return {"result": result.task_id}
 
-    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict:
+    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Initialize a job"""
-        return dict()
+        return {}
 
     def status(self, task_id: str) -> TransformationStatus:
         """Get job status"""
         result = AsyncResult(id=task_id, app=app)
-        ts = TransformationStatus(id=task_id, status=result.state)
-        return ts
+        return TransformationStatus(id=task_id, status=result.state)
 
-    def get(self, session_id: Optional[str] = None) -> Dict:
-        """get transformation"""
-
-        # TODO: update and return global state
-        return dict()
+    def get(self, session_id: Optional[str] = None) -> Dict[str, Any]:
+        """Get transformation."""
+        # TODO: update and return global state  # pylint: disable=fixme
+        return {}

--- a/oteapi/strategies/transformation/celery_remote.py
+++ b/oteapi/strategies/transformation/celery_remote.py
@@ -33,7 +33,7 @@ class CeleryRemoteStrategy:
     def run(self, session_id: Optional[str] = None) -> Dict[str, Any]:
         """Run a job, return a jobid"""
         config = self.transformation_config.configuration
-        celeryConfig = CeleryConfig(**config)
+        celeryConfig = CeleryConfig() if config is None else CeleryConfig(**config)
         result = app.send_task(
             celeryConfig.taskName, celeryConfig.args, kwargs=session_id
         )

--- a/oteapi/strategies/transformation/celery_remote.py
+++ b/oteapi/strategies/transformation/celery_remote.py
@@ -1,18 +1,20 @@
 """Transformation Plugin that uses the Celery framework to call remote workers."""
 # pylint: disable=unused-argument
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, List
 
 from celery import Celery
 from celery.result import AsyncResult
 from fastapi_plugins import RedisSettings
 from pydantic import BaseModel
 
-from oteapi.models.transformationconfig import (
-    TransformationConfig,
-    TransformationStatus,
-)
-from oteapi.plugins.factories import StrategyFactory
+from oteapi.models import TransformationStatus
+from oteapi.plugins import StrategyFactory
+
+if TYPE_CHECKING:
+    from typing import Dict, Optional
+
+    from oteapi.models import TransformationConfig
 
 # Connect Celery to the currently running Redis instance
 app = Celery(broker=RedisSettings().redis_url, backend=RedisSettings().redis_url)
@@ -28,18 +30,18 @@ class CeleryConfig(BaseModel):
 class CeleryRemoteStrategy:
     """Submit job to remote runner"""
 
-    transformation_config: TransformationConfig
+    transformation_config: "TransformationConfig"
 
-    def run(self, session_id: Optional[str] = None) -> Dict[str, Any]:
+    def run(self, session: "Optional[Dict[str, Any]]" = None) -> "Dict[str, Any]":
         """Run a job, return a jobid"""
         config = self.transformation_config.configuration
         celeryConfig = CeleryConfig() if config is None else CeleryConfig(**config)
-        result = app.send_task(
-            celeryConfig.taskName, celeryConfig.args, kwargs=session_id
-        )
+        result = app.send_task(celeryConfig.taskName, celeryConfig.args, kwargs=session)
         return {"result": result.task_id}
 
-    def initialize(self, session: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    def initialize(
+        self, session: "Optional[Dict[str, Any]]" = None
+    ) -> "Dict[str, Any]":
         """Initialize a job"""
         return {}
 
@@ -48,7 +50,7 @@ class CeleryRemoteStrategy:
         result = AsyncResult(id=task_id, app=app)
         return TransformationStatus(id=task_id, status=result.state)
 
-    def get(self, session_id: Optional[str] = None) -> Dict[str, Any]:
+    def get(self, session: "Optional[Dict[str, Any]]" = None) -> "Dict[str, Any]":
         """Get transformation."""
         # TODO: update and return global state  # pylint: disable=fixme
         return {}

--- a/oteapi/strategies/transformation/celery_remote.py
+++ b/oteapi/strategies/transformation/celery_remote.py
@@ -13,7 +13,6 @@ from oteapi.models.transformationconfig import (
 )
 from oteapi.plugins.factories import StrategyFactory
 
-
 # Connect Celery to the currently running Redis instance
 app = Celery(broker=RedisSettings().redis_url, backend=RedisSettings().redis_url)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,11 @@ requires = [
     "wheel"
 ]
 build-backend = "setuptools.build_meta"
+
+[tool.mypy]
+python_version = "3.9"
+ignore_missing_imports = true
+scripts_are_modules = true
+warn_unused_configs = true
+show_error_codes = true
+allow_redefinition = true

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,4 @@
+pre-commit~=2.16
 pylint~=2.12
 pytest~=6.2
 pytest-cov~=3.0

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,9 @@ TOP_DIR = Path(__file__).resolve().parent
 PACKAGE_NAME = "oteapi-core"
 
 with open(
-    TOP_DIR / PACKAGE_NAME.split("-")[0] / "__init__.py", "r", encoding="utf8"
+    TOP_DIR / PACKAGE_NAME.split("-", maxsplit=1)[0] / "__init__.py",
+    "r",
+    encoding="utf8",
 ) as handle:
     VERSION = AUTHOR = AUTHOR_EMAIL = None
     for line in handle.readlines():
@@ -33,7 +35,7 @@ with open(
         if value is None:
             raise RuntimeError(
                 f"Could not determine {info} from "
-                f"{TOP_DIR / PACKAGE_NAME.split('-')[0] / '__init__.py'} !"
+                f"{TOP_DIR / PACKAGE_NAME.split('-', maxsplit=1)[0] / '__init__.py'} !"
             )
     VERSION = VERSION.group("version")  # type: ignore[union-attr]
     AUTHOR = AUTHOR.group("author")  # type: ignore[union-attr]

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 """Setup for OTE-API."""
-from pathlib import Path
 import re
+from pathlib import Path
 
 from setuptools import find_packages, setup
 

--- a/tasks.py
+++ b/tasks.py
@@ -5,8 +5,8 @@ More information on `invoke` can be found at http://www.pyinvoke.org/.
 # pylint: disable=import-outside-toplevel,too-many-locals
 import re
 import sys
-from typing import TYPE_CHECKING
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from invoke import task
 


### PR DESCRIPTION
Closes #16.

This also closes an older issue from the GitLab times - namely implementing the use of [mypy](https://mypy.readthedocs.io/).

The following `pre-commit` hooks have been implemented:
- `black`
- `bandit`
- `pylint` (with special ignore-patterns only for the `strategies` module)
- `mypy`
- `isort`
- `pre-commit-hooks` (various different hooks)

Furthermore, the code has been updated to comply with all these tools.