### PR TITLE
Avoid calling asyncio run from within a running event loop

### DIFF
--- a/oteapi/datacache/datacache.py
+++ b/oteapi/datacache/datacache.py
@@ -77,7 +77,15 @@ def asyncrun(func, *args) -> "Any":
         result = await future
         return result
 
-    return asyncio.run(async_func(args))
+    try:
+        # Will raise a RuntimeError if there is no event loop
+        asyncio.get_running_loop()
+    except RuntimeError:
+        # no event loop
+        return asyncio.run(async_func(args))
+    else:
+        # within a running event loop
+        return await func(*args)
 
 
 class DataCache:

--- a/oteapi/datacache/datacache.py
+++ b/oteapi/datacache/datacache.py
@@ -80,12 +80,17 @@ def asyncrun(func, *args) -> "Any":
         # Will raise a RuntimeError if there is no event loop
         loop = asyncio.get_running_loop()
     except RuntimeError:
-        # no event loop - just return
+        # -- no event loop - just return
         return func(*args)
     else:
-        # within a running event loop - submit the async_func
-        # coroutine to the running event loop
-        return asyncio.run_coroutine_threadsafe(async_func(args), loop)
+        # -- within a running event loop - submit the async_func
+        #    coroutine to the running event loop
+
+        # This doesn't work!
+        # return asyncio.run_coroutine_threadsafe(async_func(args), loop)
+
+        # just run without asyncio wait for now...
+        return func(*args)
 
 
 class DataCache:

--- a/oteapi/datacache/datacache.py
+++ b/oteapi/datacache/datacache.py
@@ -85,7 +85,7 @@ def asyncrun(func, *args) -> "Any":
         return asyncio.run(async_func(args))
     else:
         # within a running event loop
-        return await func(*args)
+        return func(*args)
 
 
 class DataCache:

--- a/oteapi/datacache/datacache.py
+++ b/oteapi/datacache/datacache.py
@@ -74,18 +74,18 @@ def asyncrun(func, *args) -> "Any":
     async def async_func(args):
         loop = asyncio.get_running_loop()
         future = loop.run_in_executor(None, func, *args)
-        result = await future
-        return result
+        return await future
 
     try:
         # Will raise a RuntimeError if there is no event loop
-        asyncio.get_running_loop()
+        loop = asyncio.get_running_loop()
     except RuntimeError:
-        # no event loop
-        return asyncio.run(async_func(args))
-    else:
-        # within a running event loop
+        # no event loop - just return
         return func(*args)
+    else:
+        # within a running event loop - submit the async_func
+        # coroutine to the running event loop
+        return asyncio.run_coroutine_threadsafe(async_func(args), loop)
 
 
 class DataCache:


### PR DESCRIPTION
Closes #26 

oteapi-services runs from an asyncio event loop, but asyncio.run() cannot be called from a running event loop.

This PR checks if we have a running event loop. If so, the datacache methods will create a asyncio coroutine and submit it to the event loop. Thanks Casper for the solution.

This is a blocking for oteapi-services