### PR TITLE
Remove asyncio from datacache

### DIFF
--- a/oteapi/datacache/datacache.py
+++ b/oteapi/datacache/datacache.py
@@ -47,6 +47,9 @@ def gethash(
             calculating the hash.
         json_encoder: Customised json encoder for complex Python objects.
 
+    Returns:
+        A hash of the input `value`.
+
     """
     if isinstance(value, (bytes, bytearray)):
         data = value
@@ -146,12 +149,13 @@ class DataCache:
 
         Args:
             value: The value to add to the cache.
-            key: If given, use this as the retrieval key.  Otherwise the key
+            key: If given, use this as the retrieval key. Otherwise the key
                 is either taken from the `accessKey` configuration or generated
                 as a hash of `value`.
             expire: If given, the number of seconds before the value expire.
                 Otherwise it is taken from the configuration.
-            tag: Tag used with evict() for cleaning up a session.
+            tag: Tag used with [`evict()`][oteapi.datacache.datacache.DataCache.evict]
+                for cleaning up a session.
 
         Returns:
             A key that can be used to retrieve `value` from cache later.
@@ -168,7 +172,7 @@ class DataCache:
         return key
 
     def get(self, key: str) -> "Any":
-        """Return the value corresponding to key.
+        """Return the value corresponding to `key`.
 
         Args:
             key: The requested cached object to retrieve a value for.

--- a/oteapi/datacache/datacache.py
+++ b/oteapi/datacache/datacache.py
@@ -1,15 +1,15 @@
 """Data cache based on DiskCache.
-See https://github.com/grantjenks/python-diskcache
+See [Python-DiskCache](https://github.com/grantjenks/python-diskcache).
 
 Features:
-- persistent cache between sessions
-- default keys are hashes of the stored data
-- works with asyncio
-- automatic expiration of cached data
-- sessions can selectively be cleaned up via tags
-- store small values in SQLite database and large values in files
-- underlying library is actively developed and tested on Linux, Mac and Windows
-- high performance
+
+- Persistent cache between sessions.
+- Default keys are hashes of the stored data.
+- Automatic expiration of cached data.
+- Sessions can selectively be cleaned up via tags.
+- Store small values in SQLite database and large values in files.
+- Underlying library is actively developed and tested on Linux, Mac and Windows.
+- High performance.
 
 """
 import hashlib
@@ -67,7 +67,13 @@ def gethash(
 
 
 class DataCache:
-    """Initialise a cache instance with the given download configuration.
+    """Initialize a cache instance with the given download configuration.
+
+    This class is also available to import from `oteapi.datacache`, e.g.:
+
+    ```python
+    from oteapi.datacache import DataCache
+    ```
 
     Args:
         config: Download configurations.
@@ -205,18 +211,18 @@ class DataCache:
         ```
 
         Args:
-            key: Key of value to write to file
+            key: Key of value to write to file.
             filename: Full path to created file. If not given, a unique
                 filename will be created.
             prefix: Prefix to prepend to the returned file name (default
-                is "oteapi-download-").
+                is `"oteapi-download-"`).
             suffix: Suffix to append to the returned file name.
-            directory: File directory if `filename` is None.
-            delete: Whether to automatically delete created file when
+            directory: File directory if `filename` is not provided (is `None`).
+            delete: Whether to automatically delete the created file when
                 leaving the context.
 
-        Returns:
-            Path object of the created file.
+        Yields:
+            Path object, referencing and representing the created file.
 
         """
         if filename:
@@ -241,6 +247,10 @@ class DataCache:
         """Remove all cache items with the given tag.
 
         Useful for cleaning up a session.
+
+        Args:
+            tag: Tag identifying objects.
+
         """
         self.diskcache.evict(tag)
 

--- a/oteapi/datacache/datacache.py
+++ b/oteapi/datacache/datacache.py
@@ -198,17 +198,16 @@ class DataCache:
         environment variables). It is readable and writable only for
         the current user.
 
-        This method is intended to be used in a `with` statement, to
-        automatically delete the file when leaving the context.
-
         Example:
+            This method is intended to be used in a `with` statement, to
+            automatically delete the file when leaving the context:
 
-        ```python
-        cache = DataCache()
-        with cache.getfile('mykey') as filename:
-            # do something with filename...
-        # filename is deleted
-        ```
+            ```python
+            cache = DataCache()
+            with cache.getfile('mykey') as filename:
+                # do something with filename...
+            # filename is deleted
+            ```
 
         Args:
             key: Key of value to write to file.

--- a/oteapi/datacache/datacache.py
+++ b/oteapi/datacache/datacache.py
@@ -25,7 +25,7 @@ from pydantic import Extra
 from oteapi.models import DataCacheConfig
 
 if TYPE_CHECKING:
-    from typing import Any, Iterator, Optional, Type, Union
+    from typing import Any, Dict, Iterator, Optional, Type, Union
 
 
 def gethash(
@@ -81,7 +81,7 @@ class DataCache:
 
     def __init__(
         self,
-        config: "Union[DataCacheConfig, dict]" = None,
+        config: "Union[DataCacheConfig, Dict[str, Any]]" = None,
         cache_dir: "Optional[Union[Path, str]]" = None,
     ) -> None:
         if config is None:
@@ -91,7 +91,10 @@ class DataCache:
         elif isinstance(config, DataCacheConfig):
             self.config = config
         else:
-            raise TypeError(config)
+            raise TypeError(
+                "config should be either a `DataCacheConfig` data model or a "
+                "dictionary."
+            )
 
         if not cache_dir:
             cache_dir = self.config.cacheDir
@@ -145,8 +148,7 @@ class DataCache:
             tag: Tag used with evict() for cleaning up a session.
 
         Returns:
-            newkey: A key that can be used to retrieve `value` from cache
-                later.
+            A key that can be used to retrieve `value` from cache later.
         """
         if not key:
             if self.config.accessKey:
@@ -160,7 +162,15 @@ class DataCache:
         return key
 
     def get(self, key: str) -> "Any":
-        """Return the value corresponding to key."""
+        """Return the value corresponding to key.
+
+        Args:
+            key: The requested cached object to retrieve a value for.
+
+        Returns:
+            The value corresponding to the `key` value.
+
+        """
         if key not in self.diskcache:
             raise KeyError(key)
         return self.diskcache.get(key)
@@ -178,7 +188,7 @@ class DataCache:
         """Write the value for `key` to file and return the filename.
 
         The file is created in the default directory for temporary
-        files (which can be controlled by the TEMPDIR, TEMP or TMP
+        files (which can be controlled by the `TEMPDIR`, `TEMP` or `TMP`
         environment variables). It is readable and writable only for
         the current user.
 


### PR DESCRIPTION
Fix #26 

Removed asyncio from datacache. 

**Note** that this makes datacache blocking. It will most likely not have any consequences since it is very fast (only store data already existing in memory to a dict-like memory buffer (and possible synchronised to disk for large datasets)). But we may anyway consider to make a non-blocking implementation in the future.  The diskcache documentation has several useful recipies and benchmarks.

When merged we should make a release such that we can clean up oteapi-services.

Replaces PR #27 