### PR TITLE
Implement CI/CD for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+version: 2
+updates:
+- package-ecosystem: pip
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: monday
+    time: "05:18"
+  # Should be bigger than or equal to the total number of dependencies (currently 19)
+  open-pull-requests-limit: 30
+  target-branch: ci/dependabot-updates
+  labels:
+    - dependencies
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "05:24"
+  target-branch: ci/dependabot-updates
+  labels:
+    - github_actions

--- a/.github/utils/single_dependency_pr_body.txt
+++ b/.github/utils/single_dependency_pr_body.txt
@@ -1,0 +1,10 @@
+### Update dependencies
+
+Automatically created PR from [`ci/dependabot-updates`](https://github.com/EMMC-ASBL/oteapi-core/tree/ci/dependabot-updates).
+
+For more information see the ["Dependabot updates" workflow](https://github.com/EMMC-ASBL/oteapi-core/blob/master/.github/workflows/ci_dependabot.yml).
+
+#### To-do
+
+- [ ] Check that the diff is sensible, and that tests and builds pass with the new dependency versions.
+- [ ] Make sure that the PR is **squash** merged, with a sensible commit message.

--- a/.github/workflows/ci_automerge_dependabot.yml
+++ b/.github/workflows/ci_automerge_dependabot.yml
@@ -1,0 +1,25 @@
+name: CI - Activate auto-merging for Dependabot PRs
+
+on:
+  pull_request_target:
+    branches: [ci/dependabot-updates]
+
+jobs:
+  update-dependabot-branch:
+    name: Update permanent dependabot branch
+    if: github.repository_owner == 'EMMC-ASBL' && startsWith(github.event.pull_request.head.ref, 'dependabot/') && github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.ref }}
+
+    - name: Activate auto-merge
+      run: |
+        PR_ID="$(gh api graphql -F owner='{owner}' -F name='{repo}' -f query='query($owner: String!, $name: String!) {repository(owner: $owner, name: $name) {pullRequest(number: ${{ github.event.pull_request.number }}) {id}}}' --jq '.data.repository.pullRequest.id')"
+        gh api graphql -f pr_id="$PR_ID" -f query='mutation($pr_id: String!) {enablePullRequestAutoMerge(input:{mergeMethod:SQUASH,pullRequestId:$pr_id }) {pullRequest {number}}}'
+      env:
+        GITHUB_TOKEN: ${{ secrets.RELEASE_PAT }}

--- a/.github/workflows/ci_cd_updated_master.yml
+++ b/.github/workflows/ci_cd_updated_master.yml
@@ -5,57 +5,57 @@ on:
     branches: [master]
 
 env:
-  # DEPENDABOT_BRANCH: ci/dependabot-updates
+  DEPENDABOT_BRANCH: ci/dependabot-updates
   GIT_USER_NAME: "TEAM 4.0[bot]"
   GIT_USER_EMAIL: "Team4.0@SINTEF.onmicrosoft.com"
   DEFAULT_REPO_BRANCH: master
 
 jobs:
-  # update-dependabot-branch:
-  #   name: Update permanent dependabot branch
-  #   if: github.repository_owner == 'EMMC-ASBL'
-  #   runs-on: ubuntu-latest
+  update-dependabot-branch:
+    name: Update permanent dependabot branch
+    if: github.repository_owner == 'EMMC-ASBL'
+    runs-on: ubuntu-latest
 
-  #   steps:
-  #   - name: Checkout repository
-  #     uses: actions/checkout@v2
-  #     with:
-  #       ref: ${{ env.DEPENDABOT_BRANCH }}
-  #       fetch-depth: 0
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        ref: ${{ env.DEPENDABOT_BRANCH }}
+        fetch-depth: 0
 
-  #   - name: Set up git config
-  #     run: |
-  #       git config --global user.name "${{ env.GIT_USER_NAME }}"
-  #       git config --global user.email "${{ env.GIT_USER_EMAIL }}"
+    - name: Set up git config
+      run: |
+        git config --global user.name "${{ env.GIT_USER_NAME }}"
+        git config --global user.email "${{ env.GIT_USER_EMAIL }}"
 
-  #   - name: Update '${{ env.DEPENDABOT_BRANCH }}'
-  #     run: |
-  #       git fetch origin
+    - name: Update '${{ env.DEPENDABOT_BRANCH }}'
+      run: |
+        git fetch origin
 
-  #       LATEST_PR_BODY="$(gh api /repos/${{ github.repository}}/pulls -X GET -f state=closed -f per_page=1 -f sort=updated -f direction=desc --jq '.[].body')"
-  #       cat .github/utils/single_dependency_pr_body.txt | head -8 > .tmp_file.txt
-  #       if [ -z "$(printf '%s\n' "${LATEST_PR_BODY}" | head -8 | diff - .tmp_file.txt --strip-trailing-cr)" ]; then
-  #         # The dependency branch has just been merged into `${{ env.DEFAULT_REPO_BRANCH }}`
-  #         # The dependency branch should be reset to `${{ env.DEFAULT_REPO_BRANCH }}`
-  #         echo "The dependencies have just been updated! Reset to ${{ env.DEFAULT_REPO_BRANCH }}."
-  #         git reset --hard origin/${{ env.DEFAULT_REPO_BRANCH }}
-  #         echo "FORCE_PUSH=yes" >> $GITHUB_ENV
-  #       else
-  #         # Normal procedure: Merge `${{ env.DEFAULT_REPO_BRANCH }}` into `${{ env.DEPENDABOT_BRANCH }}`
-  #         echo "Merge new updates to ${{ env.DEFAULT_REPO_BRANCH }} into ${{ env.DEPENDABOT_BRANCH }}"
-  #         git merge -m "Keep '${{ env.DEPENDABOT_BRANCH }}' up-to-date with '${{ env.DEFAULT_REPO_BRANCH }}'" origin/${{ env.DEFAULT_REPO_BRANCH }}
-  #         echo "FORCE_PUSH=no" >> $GITHUB_ENV
-  #       fi
-  #     env:
-  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        LATEST_PR_BODY="$(gh api /repos/${{ github.repository}}/pulls -X GET -f state=closed -f per_page=1 -f sort=updated -f direction=desc --jq '.[].body')"
+        cat .github/utils/single_dependency_pr_body.txt | head -8 > .tmp_file.txt
+        if [ -z "$(printf '%s\n' "${LATEST_PR_BODY}" | head -8 | diff - .tmp_file.txt --strip-trailing-cr)" ]; then
+          # The dependency branch has just been merged into `${{ env.DEFAULT_REPO_BRANCH }}`
+          # The dependency branch should be reset to `${{ env.DEFAULT_REPO_BRANCH }}`
+          echo "The dependencies have just been updated! Reset to ${{ env.DEFAULT_REPO_BRANCH }}."
+          git reset --hard origin/${{ env.DEFAULT_REPO_BRANCH }}
+          echo "FORCE_PUSH=yes" >> $GITHUB_ENV
+        else
+          # Normal procedure: Merge `${{ env.DEFAULT_REPO_BRANCH }}` into `${{ env.DEPENDABOT_BRANCH }}`
+          echo "Merge new updates to ${{ env.DEFAULT_REPO_BRANCH }} into ${{ env.DEPENDABOT_BRANCH }}"
+          git merge -m "Keep '${{ env.DEPENDABOT_BRANCH }}' up-to-date with '${{ env.DEFAULT_REPO_BRANCH }}'" origin/${{ env.DEFAULT_REPO_BRANCH }}
+          echo "FORCE_PUSH=no" >> $GITHUB_ENV
+        fi
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  #   - name: Push to '${{ env.DEPENDABOT_BRANCH }}'
-  #     uses: CasperWA/push-protected@v2
-  #     with:
-  #       token: ${{ secrets.RELEASE_PAT }}
-  #       branch: ${{ env.DEPENDABOT_BRANCH }}
-  #       sleep: 15
-  #       force: ${{ env.FORCE_PUSH }}
+    - name: Push to '${{ env.DEPENDABOT_BRANCH }}'
+      uses: CasperWA/push-protected@v2
+      with:
+        token: ${{ secrets.RELEASE_PAT }}
+        branch: ${{ env.DEPENDABOT_BRANCH }}
+        sleep: 15
+        force: ${{ env.FORCE_PUSH }}
 
   deploy-docs:
     name: Deploy `latest` documentation

--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -1,0 +1,103 @@
+name: CI - Single Dependabot PR
+
+on:
+  schedule:
+    # At 8:30 every Wednesday (6:30 UTC)
+    # Dependabot runs once a week (every Monday) (pip)
+    # and every day (GH Actions) between 7:00 and 7:30 (5:00-5:30 UTC)
+    - cron: "30 6 * * 3"
+
+jobs:
+  create-collected-pr:
+    name: Single dependabot PR
+    if: github.repository_owner == 'EMMC-ASBL'
+    runs-on: ubuntu-latest
+    env:
+      DEPENDABOT_BRANCH: ci/dependabot-updates
+      GIT_USER_NAME: "TEAM 4.0[bot]"
+      GIT_USER_EMAIL: "Team4.0@SINTEF.onmicrosoft.com"
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        ref: master
+
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+
+    - name: Install `pre-commit` and dependencies
+      run: |
+        python -m pip install -U pip
+        pip install -U setuptools wheel
+
+        while IFS="" read -r line || [ -n "${line}" ]; do
+          if [[ "${line}" =~ ^pre-commit.*$ ]]; then
+            pre_commit="${line}"
+          fi
+        done < requirements_dev.txt
+
+        while IFS="" read -r line || [ -n "${line}" ]; do
+          if [[ "${line}" =~ ^invoke.*$ ]]; then
+            invoke="${line}"
+          fi
+        done < requirements_docs.txt
+
+        pip install ${pre_commit} ${invoke}
+
+    - name: Set up git user info
+      run: |
+        git config --global user.name "${{ env.GIT_USER_NAME }}"
+        git config --global user.email "${{ env.GIT_USER_EMAIL }}"
+
+    - name: Reset to '${{ env.DEPENDABOT_BRANCH }}'
+      run: |
+        git fetch origin ${{ env.DEPENDABOT_BRANCH }}:${{ env.DEPENDABOT_BRANCH }}
+        git reset --hard ${{ env.DEPENDABOT_BRANCH }}
+
+    - name: Auto-update `pre-commit` hooks
+      run: |
+        pre-commit autoupdate
+
+        if [ -n "$(git status --porcelain .pre-commit-config.yaml)" ]; then
+          # Set environment variable notifying next steps that the hooks changed
+          echo "Pre-commit hooks have been updated !"
+          echo "UPDATED_PRE_COMMIT_HOOKS=true" >> $GITHUB_ENV
+        else
+          echo "No pre-commit hooks have been updated."
+          echo "UPDATED_PRE_COMMIT_HOOKS=false" >> $GITHUB_ENV
+        fi
+
+    - name: Possibly run `pre-commit` with updated hooks
+      if: env.UPDATED_PRE_COMMIT_HOOKS == 'true'
+      continue-on-error: true  # Still create the PR if this step fails
+      run: SKIP=pylint pre-commit run --all-files
+
+    - name: Possibly commit changes and updates
+      if: env.UPDATED_PRE_COMMIT_HOOKS == 'true'
+      run: git commit -am "Update \`pre-commit\` hooks"
+
+    - name: Fetch PR body
+      id: pr_body
+      uses: chuhlomin/render-template@v1.4
+      with:
+        template: .github/utils/single_dependency_pr_body.txt
+
+    - name: Create PR
+      id: cpr
+      uses: peter-evans/create-pull-request@v3
+      with:
+        token: ${{ secrets.RELEASE_PAT }}
+        commit-message: New @dependabot-fueled updates
+        committer: "${{ env.GIT_USER_NAME }} <${{ env.GIT_USER_EMAIL }}>"
+        author: "${{ env.GIT_USER_NAME }} <${{ env.GIT_USER_EMAIL }}>"
+        branch: ci/update-dependencies
+        delete-branch: true
+        title: "[Auto-generated] Update dependencies"
+        body: ${{ steps.pr_body.outputs.result }}
+        labels: dependencies,github_actions
+
+    - name: Information
+      run: 'echo "${{ steps.cpr.outputs.pull-request-operation }} PR #${{ steps.cpr.outputs.pull-request-number }}: ${{ steps.cpr.outputs.pull-request-url }}"'


### PR DESCRIPTION
Closes #31 

The workflows for dependabot are there to auto-merge the dependabot PRs
that will arise into a separate branch `ci/dependabot-updates`.
Also for creating a single PR to update dependencies and pre-commit
versions once a week - one can consider moving this to a less frequent
timing.
A workflow also updates the separate branch `ci/dependabot-updates` with
the changes from `master` on every push to `master`.

I have already created the permanent separate branch `ci/dependabot-updates`.