### PR TITLE
Install the `dev` extra in publish workflow

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -32,7 +32,7 @@ jobs:
       run: |
         python -m pip install -U pip
         pip install -U setuptools wheel build
-        pip install -U -e .
+        pip install -U -e .[dev]
 
     - name: Update changelog
       uses: CharMixer/auto-changelog-action@v1


### PR DESCRIPTION
This ensures all relevant dependencies are installed.

Fixes #40 