### PR TITLE
Add Windows pytest CI job

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -76,7 +76,7 @@ jobs:
     - name: Run safety
       run: pip freeze | safety check --stdin
 
-  pytest:
+  pytest-linux:
     runs-on: ubuntu-latest
     # timeout-minutes: 15
 
@@ -108,9 +108,43 @@ jobs:
       if: matrix.python-version == 3.9 && github.repository == 'EMMC-ASBL/oteapi-core'
       uses: codecov/codecov-action@v2
       with:
-        name: oteapi-core
-        files: ./coverage.xml
-        flags: pytest
+        files: coverage.xml
+        flags: linux
+
+  pytest-win:
+    runs-on: windows-latest
+    # timeout-minutes: 15
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10"]
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 2
+
+    - name: Set up Python ${{ matrix.python-version}}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version}}
+
+    - name: Install python dependencies
+      run: |
+        python -m pip install -U pip
+        pip install -U setuptools wheel
+        pip install -e .[dev]
+
+    - name: Test with pytest
+      run: pytest -vvv --cov-report=xml
+
+    - name: Upload coverage to Codecov
+      if: matrix.python-version == 3.9 && github.repository == 'EMMC-ASBL/oteapi-core'
+      uses: codecov/codecov-action@v2
+      with:
+        files: coverage.xml
+        flags: windows
 
   build-package:
     name: Build distribution package

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ allow_redefinition = true
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "-rs --cov=./oteapi/ --cov-report=term --durations=10"
+addopts = "-rs --cov=oteapi --cov-report=term --durations=10"
 filterwarnings = [
     "ignore:.*imp module.*:DeprecationWarning",
     "ignore:.*_yaml extension module.*:DeprecationWarning"


### PR DESCRIPTION
Fixes #51 

Add a Windows pytest CI job.
Update codecov flags to reflect the OS.

Use OS-agnostic option value in `pyproject.toml`.