### PR TITLE
EntryPoint duplicity

### DIFF
--- a/oteapi/plugins/entry_points.py
+++ b/oteapi/plugins/entry_points.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover
     from importlib.metadata import EntryPoint
-    from typing import Any, Iterable, Iterator, Optional, Set, Tuple, Type, Union
+    from typing import Any, Iterator, Optional, Set, Tuple, Type, Union
 
     from oteapi.interfaces import IStrategy
 
@@ -502,14 +502,13 @@ def get_strategy_entry_points(
         ) from exc
 
     collection = EntryPointStrategyCollection()
-    for group, oteapi_entry_points in get_entry_points().items():
-        if group.startswith("oteapi.") and group[len("oteapi.") :] == str(
-            strategy_type.value
-        ):
-            if enforce_uniqueness:
-                collection.exclusive_add(
-                    *(EntryPointStrategy(_) for _ in oteapi_entry_points)
-                )
-            else:
-                collection.add(*(EntryPointStrategy(_) for _ in oteapi_entry_points))
+    oteapi_entry_points = sorted(
+        set(get_entry_points().get(f"oteapi.{strategy_type.value}", []))
+    )
+
+    if enforce_uniqueness:
+        collection.exclusive_add(*(EntryPointStrategy(_) for _ in oteapi_entry_points))
+    else:
+        collection.add(*(EntryPointStrategy(_) for _ in oteapi_entry_points))
+
     return collection

--- a/tests/datacache/test_datacache.py
+++ b/tests/datacache/test_datacache.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from pathlib import Path
 
 

--- a/tests/models/test_genericconfig.py
+++ b/tests/models/test_genericconfig.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from oteapi.models.genericconfig import GenericConfig
 
 

--- a/tests/plugins/conftest.py
+++ b/tests/plugins/conftest.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from importlib.metadata import EntryPoint
     from typing import Any, Callable, Dict, Iterable, Tuple, Type, Union
 

--- a/tests/plugins/test_entry_points.py
+++ b/tests/plugins/test_entry_points.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from importlib.metadata import EntryPoint
     from typing import Any, Callable, Dict, Iterable, Tuple, Union
 

--- a/tests/plugins/test_entry_points.py
+++ b/tests/plugins/test_entry_points.py
@@ -155,3 +155,54 @@ def test_eval_custom_classes() -> None:
         == eval_collection_cls._entry_points
         == {normal_strategy_cls}
     )
+
+
+@pytest.mark.parametrize(
+    "enforce_uniqueness", (True, False), ids=("uniqueness", "no uniqueness")
+)
+def test_duplicate_entry_points(
+    mock_importlib_entry_points: "MockEntryPoints",
+    enforce_uniqueness: bool,
+) -> None:
+    """Ensure duplicate entry points does not result in an error.
+
+    Note: This is for duplicate entry points, NOT entry point _strategies_.
+    """
+    strategy_type = "download"
+    test_entry_points = [
+        {
+            "name": "package_one.file",
+            "value": "package_one.strategies.file:FileStrategy",
+            "group": f"oteapi.{strategy_type}",
+        },
+        {
+            "name": "package_two.http",
+            "value": "package_two.strategies.http:HTTPStrategy",
+            "group": f"oteapi.{strategy_type}",
+        },
+    ]
+    # Must be called prior to importing anything from `oteapi`
+    mock_importlib_entry_points(test_entry_points + test_entry_points)
+
+    from oteapi.plugins.entry_points import (
+        EntryPointStrategy,
+        get_entry_points,
+        get_strategy_entry_points,
+    )
+
+    assert len(get_entry_points().get(f"oteapi.{strategy_type}", [])) == 2 * len(
+        test_entry_points
+    )
+
+    collection = get_strategy_entry_points(
+        strategy_type, enforce_uniqueness=enforce_uniqueness
+    )
+
+    assert len(collection) == len(test_entry_points)
+
+    for test_entry_point in test_entry_points:
+        assert (
+            f"oteapi.{strategy_type}"
+            f"{EntryPointStrategy.ENTRY_POINT_NAME_SEPARATOR}"
+            f"{test_entry_point.get('name', '')}"
+        ) in collection

--- a/tests/plugins/test_entry_points_entrypointstrategy.py
+++ b/tests/plugins/test_entry_points_entrypointstrategy.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from importlib.metadata import EntryPoint
     from typing import Any, Callable, Dict, Iterable, List, Tuple, Union
 

--- a/tests/plugins/test_factories.py
+++ b/tests/plugins/test_factories.py
@@ -3,7 +3,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from importlib.metadata import EntryPoint
     from typing import Any, Callable, Dict, Iterable, Type, Union
 

--- a/tests/static/strategies/download.py
+++ b/tests/static/strategies/download.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from typing import Any, Dict, Optional
 
     from oteapi.models import ResourceConfig

--- a/tests/static/strategies/filter.py
+++ b/tests/static/strategies/filter.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from typing import Any, Dict, Optional
 
     from oteapi.models import FilterConfig

--- a/tests/static/strategies/function.py
+++ b/tests/static/strategies/function.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from typing import Any, Dict, Optional
 
     from oteapi.models import FunctionConfig

--- a/tests/static/strategies/mapping.py
+++ b/tests/static/strategies/mapping.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from typing import Any, Dict, Optional
 
     from oteapi.models import MappingConfig

--- a/tests/static/strategies/parse.py
+++ b/tests/static/strategies/parse.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from typing import Any, Dict, Optional
 
     from oteapi.models import ResourceConfig

--- a/tests/static/strategies/resource.py
+++ b/tests/static/strategies/resource.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from typing import Any, Dict, Optional
 
     from oteapi.models import ResourceConfig

--- a/tests/static/strategies/transformation.py
+++ b/tests/static/strategies/transformation.py
@@ -3,7 +3,7 @@
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from typing import Any, Dict, Optional
 
     from oteapi.models import TransformationConfig, TransformationStatus


### PR DESCRIPTION
Fixes #86 

Casts the tuple of `importlib.metadata.EntryPoint`s to a set, removing duplicates, and then to a sorted list via the built-in function `sorted()`, which should return the original order in the original tuple.

A test has been added to check whether duplicate `EntryPoint`s can now be handled as intended.

Note: It is important to differentiate between duplicate `EntryPoint`s and entry point _strategies_. The former is the Python representation of `setuptools`' entry points registered in the environment through `pip install` calls (or similar). The latter is a special Python object from the class `oteapi.plugins.entry_points.EntryPointStrategy` that represents an entry point that is an OTE API strategy. There duplication is based on more strategy-specific information.

As an extra - the unnecessary comment `# pragma: no cover` has been removed for all files under `tests/`, since this is a comment for the code coverage to understand that it should disregard this code line and possibly its associated block. Code coverage is not considered for any files under `tests/`, so it has no meaning and is just unnecessary characters that can be removed.