### PR TITLE
Add test for AttrDict.update() method

### DIFF
--- a/oteapi/models/genericconfig.py
+++ b/oteapi/models/genericconfig.py
@@ -83,7 +83,7 @@ class AttrDict(BaseModel, Mapping):
         self, other: "Optional[Union[dict, AttrDict, Iterable[Any]]]" = None, **kwargs
     ) -> None:
         """MutableMapping `update`-method."""
-        if other and isinstance(other, (dict, self.__class__)):
+        if other and isinstance(other, (dict, Mapping)):
             for key, value in other.items():
                 setattr(self, key, value)
         elif other and isinstance(other, Iterable):

--- a/tests/models/test_genericconfig.py
+++ b/tests/models/test_genericconfig.py
@@ -97,8 +97,10 @@ def test_attrdict_update() -> None:
     final_data = data.copy()
     final_data.update(update_data)
 
-    for other_type in (dict, AttrDict, SubAttrDict, SubSubAttrDict):
-        attr_dict = AttrDict(**data)
-        other = other_type(**update_data)
-        attr_dict.update(other)
-        assert {**attr_dict} == final_data
+    testing_types = (dict, AttrDict, SubAttrDict, SubSubAttrDict)
+    for original_type in testing_types:
+        for other_type in testing_types:
+            original = original_type(**data)
+            other = other_type(**update_data)
+            original.update(other)
+            assert {**original} == final_data

--- a/tests/models/test_genericconfig.py
+++ b/tests/models/test_genericconfig.py
@@ -76,3 +76,29 @@ def test_attrdict() -> None:
     assert config.b == config["b"] == config.get("b") == data["b"]
 
     assert {**config} == data
+
+
+def test_attrdict_update() -> None:
+    """Test supplying `AttrDict.update()` with different (valid) types."""
+    from pydantic import Field
+
+    from oteapi.models.genericconfig import AttrDict
+
+    class SubAttrDict(AttrDict):
+        """1st level sub-class of AttrDict."""
+
+    class SubSubAttrDict(SubAttrDict):
+        """2nd level sub-class of AttrDict."""
+
+        test: SubAttrDict = Field(SubAttrDict())
+
+    data = {"a": 1, "b": "foo", "c": "bar"}
+    update_data = {"a": 2, "c": "bar", "d": "baz", "test": {"key": "value"}}
+    final_data = data.copy()
+    final_data.update(update_data)
+
+    for other_type in (dict, AttrDict, SubAttrDict, SubSubAttrDict):
+        attr_dict = AttrDict(**data)
+        other = other_type(**update_data)
+        attr_dict.update(other)
+        assert {**attr_dict} == final_data


### PR DESCRIPTION
Fixes #101 

~It seems there is no issue and the issue from which this originates lies elsewhere.~
This simply adds a test for expected valid types to be used with `AttrDict.update()`.

The test has been expanded to also vary the "original" type from which the `update()` method is called.
I.e., the tests now actually tests the interchangeability of types when using the `update()` method on `dict` or `AttrDict` or any sub-class thereof.

The expected error was also found - and fixed by replacing the check for `self.__class__` with `Mapping`.