### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,32 @@ The plugins will then automagically load all installed strategy module plugins, 
 
 OTEAPI Core can be installed with:
 
-```console
-$ pip install oteapi-core
+```shell
+pip install oteapi-core
 ```
+
+### For developers
+
+If you want to install OTEAPI Core to have a developer environment, please clone down the repository from GitHub and install:
+
+```shell
+git clone https://github.com/EMMC-ASBL/oteapi-core /path/to/oteapi-core
+pip install -U --upgrade-strategy=eager -e /path/to/oteapi-core[dev]
+```
+
+Note, `/path/to/oteapi-core` can be left out of the first line, but then it must be updated in the second line, either to `./oteapi-core`/`oteapi-core` or `.` if you `cd` into the generated folder wherein the repository has been cloned.
+
+The `--upgrade-strategy=eager` part can be left out.
+We recommend installing within a dedicated virtual environment.
+
+To test the installation, you can run:
+
+```shell
+cd /path/to/oteapi-core
+pytest
+```
+
+If you run into issues at this stage, please [open an issue](https://github.com/EMMC-ASBL/oteapi-core/issues/new).
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Parse strategy patterns convert content from the data cache to a Python dict.
 Like download strategies, they are configured with the `ResourceConfig` data model, using the `mediaType` field for strategy selection.
 Additional strategy-specific configurations can be provided via the `configuration` field.
 
-Standard parse strategies: *text_csv*, *application_json*, *image*, *excel_xlsx*
+Standard parse strategies: *application/json*, *image/jpg*, *image/jpeg*, *image/jp2*, *image/png*, *image/gif*, *image/tiff*, *image/eps*, *application/vnd.openxmlformats-officedocument.spreadsheetml.sheet*, *application/vnd.sqlite3*
 
 ### Resource strategy
 
@@ -53,62 +53,138 @@ Strategies for mapping fields/properties in data models to ontological concepts.
 Filter strategies can update the configuration of other strategies.
 They can also update values in the data cache.
 
+Standard filter strategies: *filter/crop*, *filter/sql*
+
+### Function strategy
+
+Function strategies are synchronous transformations that (normally) run directly on the server hosting the OTE service.
+
 ### Transformation strategy
 
-Transformation strategies are a special form of a filter strategy intended for long-running transformations.
+Transformation strategies are a special form of a function strategy intended for long-running transformations.
+In this sense, they represent asynchronous functions running in the background or on external resources.
+
+Standard transformation strategies: *celery/remote*
 
 ## Entry points for plugins
 
-Suggestion: Use setuptools entry points to load plugins.
+The way strategies are registered and found is through [entry points](https://packaging.python.org/en/latest/specifications/entry-points/).
 
-The entry point groups could be named as something like this:
+Special group names allow understanding the strategy type and the entry point values allow understanding of what kind of strategy a specific class implements.
+A full overview of recognized entry point group names can be seen in [Table of entry point strategies](#table-of-entry-point-strategies).
 
-* `"oteapi.download_strategy"`, `"oteapi.filter_strategy"`
-* `"oteapi.download"`, `"oteapi.filter"`
-* `"oteapi.interfaces.download"`, `"oteapi.interfaces.filter"`
+### Defining entry points
 
-The value for an entrypoint should then be:
+In the following examples, let's imagine we have a package importable in Python through `my_plugin` and contains two download strategies and a single parse strategy:
+
+1. A peer-2-peer download strategy, implemented in a class named `Peer2PeerDownload` importable from `my_plugin.strategies.download.peer_2_peer`.
+2. A MongoDB download strategy, implemented in a class named `MongoRetrieve` importable from `my_plugin.strategies.mongo`.
+3. A MongoDB parse strategy, implemented in a class named `MongoParse` importable from `my_plugin.strategies.mongo`.
+
+There are now various different ways to let the Python environment know of these strategies through entry points.
+
+#### `setup.py`
+
+In the package's `setup.py` file, one can specify entry points.  
+Here, an example snippet is shown using [setuptools](https://setuptools.pypa.io/):
 
 ```python
+# setup.py
+from setuptools import setup
+
 setup(
     # ...,
     entry_points={
-        "oteapi.download_strategy": [
-            "my_plugin.p2p = my_plugin.strategies.download.peer_2_peer",
-            "my_plugin.mongo = my_plugin.strategies.download.mongo_get",
+        "oteapi.download": [
+            "my_plugin.p2p = my_plugin.strategies.download.peer_2_peer:Peer2PeerDownload",
+            "my_plugin.mongo = my_plugin.strategies.mongo:MongoRetrieve",
         ],
+        "oteapi.parse": [
+            "my_plugin.application/vnd.mongo+json = my_plugin.strategies.mongo:MongoParse",
+        ]
     },
 )
 ```
 
-or as part of a YAML/JSON/setup.cfg setup files as such:
+#### YAML/JSON custom files
+
+Use custom files that are later parsed and used in a `setup.py` file.
 
 ```yaml
 entry_points:
-  oteapi.download_strategy:
-  - "my_plugin.p2p = my_plugin.strategies.download.peer_2_peer"
-  - "my_plugin.mongo = my_plugin.strategies.download.mongo_get"
+  oteapi.download:
+  - "my_plugin.p2p = my_plugin.strategies.download.peer_2_peer:Peer2PeerDownload"
+  - "my_plugin.mongo = my_plugin.strategies.mongo:MongoRetrieve"
+  oteapi.parse:
+  - "my_plugin.application/vnd.mongo+json = my_plugin.strategies.mongo:MongoParse"
 ```
 
 ```json
 {
   "entry_points": {
-    "oteapi.download_strategy": [
-      "my_plugin.p2p = my_plugin.strategies.download.peer_2_peer",
-      "my_plugin.mongo = my_plugin.strategies.download.mongo_get"
+    "oteapi.download": [
+      "my_plugin.p2p = my_plugin.strategies.download.peer_2_peer:Peer2PeerDownload",
+      "my_plugin.mongo = my_plugin.strategies.mongo:MongoRetrieve"
+    ],
+    "oteapi.parse": [
+      "my_plugin.application/vnd.mongo+json = my_plugin.strategies.mongo:MongoParse"
     ]
   }
 }
 ```
 
+#### `setup.cfg`/`pyproject.toml`
+
+A more modern approach is to use `setup.cfg` or `pyproject.toml`.
+
 ```ini
 [options.entry_points]
-oteapi.download_strategy =
-    my_plugin.p2p = my_plugin.strategies.download.peer_2_peer
-    my_plugin.mongo = my_plugin.strategies.download.mongo_get
+oteapi.download =
+    my_plugin.p2p = my_plugin.strategies.download.peer_2_peer:Peer2PeerDownload
+    my_plugin.mongo = my_plugin.strategies.mongo:MongoRetrieve
+oteapi.parse =
+    my_plugin.application/vnd.mongo+json = my_plugin.strategies.mongo:MongoParse
 ```
 
-The plugins will then automagically load all installed strategy module plugins, registering the strategies according to the `StrategyFactory` decorator.
+### Syntax and semantics
+
+As seen above, there are a few different syntactical flavors of how to list the entry points.
+However, the "value" stays the same throughout.
+
+#### General Python entry points
+
+The general syntax for entry points is based on `ini` files and parsed using the built-in `configparser` module described [here](https://docs.python.org/3/library/configparser.html#module-configparser).
+Specifically for entry points the nomenclature is the following:
+
+```ini
+[options.entry_points]
+GROUP =
+    NAME = VALUE
+```
+
+The `VALUE` is then further split into: `PACKAGE.MODULE:OBJECT.ATTRIBUTE [EXTRA1, EXTRA2]`.
+
+#### OTEAPI strategy entry points
+
+From the general syntax outlined above, OTEAPI Core then implements rules and requirements regarding the syntax for strategies.
+
+1. A class *MUST* be specified (as an `OBJECT`).
+2. The `NAME` *MUST* consist of exactly two parts: `PACKAGE` and strategy type value in the form of `PACKAGE.STRATEGY_TYPE_VALUE`.
+3. The `GROUP` *MUST* be a valid OTEAPI entry point group, see [Table of entry point strategies](#table-of-entry-point-strategies) for a full list of valid OTEAPI entry point group values.
+
+To understand what the strategy type value should be, see [Table of entry point strategies](#table-of-entry-point-strategies).
+
+### Table of entry point strategies
+
+| Strategy Type Name | Strategy Type Value | Entry Point Group | Documentation Reference |
+|:---:|:---:|:---:|:--- |
+| Download | [`scheme`](oteapi/models/resourceconfig.py) | `oteapi.download` | [Download strategy](#download-strategy) |
+| Filter | [`filterType`](oteapi/models/filterconfig.py) | `oteapi.filter` | [Filter strategy](#filter-strategy) |
+| Function | [`functionType`](oteapi/models/functionconfig.py) | `oteapi.function` | [Function strategy](#function-strategy) |
+| Mapping | [`mappingType`](oteapi/models/mappingconfig.py) | `oteapi.mapping` | [Mapping strategy](#mapping-strategy) |
+| Parse | [`mediaType`](oteapi/models/resourceconfig.py) | `oteapi.parse` | [Parse strategy](#parse-strategy) |
+| Resource | [`accessService`](oteapi/models/resourceconfig.py) | `oteapi.resource` | [Resource strategy](#resource-strategy) |
+| Transformation | [`transformationType`](oteapi/models/transformationconfig.py) | `oteapi.transformation` | [Transformation strategy](#transformation-strategy) |
 
 ## Other OTEAPI-related repositories
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 > Framework for accessing data resources, mapping data models, describing the data to ontologies and perform data transformations
 
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/oteapi-core?logo=pypi)
+![PyPI](https://img.shields.io/pypi/v/oteapi-core?logo=pypi)
+![Codecov master](https://img.shields.io/codecov/c/github/EMMC-ASBL/oteapi-core/master?logo=codecov)
+![CI - Tests](https://github.com/EMMC-ASBL/oteapi-core/actions/workflows/ci_tests.yml/badge.svg?branch=master)
+![GitHub commit activity](https://img.shields.io/github/commit-activity/m/EMMC-ASBL/oteapi-core?logo=github)
+![GitHub last commit](https://img.shields.io/github/last-commit/EMMC-ASBL/oteapi-core?logo=github)
+
 We highly recommend reading this page in [the official documentation](https://emmc-asbl.github.io/oteapi-core).
 
 ## About OTEAPI Core

--- a/docs/index.md
+++ b/docs/index.md
@@ -120,9 +120,32 @@ The plugins will then automagically load all installed strategy module plugins, 
 
 OTEAPI Core can be installed with:
 
-```console
-$ pip install oteapi-core
+```shell
+pip install oteapi-core
 ```
+
+### For developers
+
+If you want to install OTEAPI Core to have a developer environment, please clone down the repository from GitHub and install:
+
+```shell
+git clone https://github.com/EMMC-ASBL/oteapi-core /path/to/oteapi-core
+pip install -U --upgrade-strategy=eager -e /path/to/oteapi-core[dev]
+```
+
+Note, `/path/to/oteapi-core` can be left out of the first line, but then it must be updated in the second line, either to `./oteapi-core`/`oteapi-core` or `.` if you `cd` into the generated folder wherein the repository has been cloned.
+
+The `--upgrade-strategy=eager` part can be left out.
+We recommend installing within a dedicated virtual environment.
+
+To test the installation, you can run:
+
+```shell
+cd /path/to/oteapi-core
+pytest
+```
+
+If you run into issues at this stage, please [open an issue](https://github.com/EMMC-ASBL/oteapi-core/issues/new).
 
 ## License
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ Parse strategy patterns convert content from the data cache to a Python dict.
 Like download strategies, they are configured with the `ResourceConfig` data model, using the `mediaType` field for strategy selection.
 Additional strategy-specific configurations can be provided via the `configuration` field.
 
-Standard parse strategies: *text_csv*, *application_json*, *image*, *excel_xlsx*
+Standard parse strategies: *application/json*, *image/jpg*, *image/jpeg*, *image/jp2*, *image/png*, *image/gif*, *image/tiff*, *image/eps*, *application/vnd.openxmlformats-officedocument.spreadsheetml.sheet*, *application/vnd.sqlite3*
 
 ### Resource strategy
 
@@ -53,62 +53,138 @@ Strategies for mapping fields/properties in data models to ontological concepts.
 Filter strategies can update the configuration of other strategies.
 They can also update values in the data cache.
 
+Standard filter strategies: *filter/crop*, *filter/sql*
+
+### Function strategy
+
+Function strategies are synchronous transformations that (normally) run directly on the server hosting the OTE service.
+
 ### Transformation strategy
 
-Transformation strategies are a special form of a filter strategy intended for long-running transformations.
+Transformation strategies are a special form of a function strategy intended for long-running transformations.
+In this sense, they represent asynchronous functions running in the background or on external resources.
+
+Standard transformation strategies: *celery/remote*
 
 ## Entry points for plugins
 
-Suggestion: Use setuptools entry points to load plugins.
+The way strategies are registered and found is through [entry points](https://packaging.python.org/en/latest/specifications/entry-points/).
 
-The entry point groups could be named as something like this:
+Special group names allow understanding the strategy type and the entry point values allow understanding of what kind of strategy a specific class implements.
+A full overview of recognized entry point group names can be seen in [Table of entry point strategies](#table-of-entry-point-strategies).
 
-* `"oteapi.download_strategy"`, `"oteapi.filter_strategy"`
-* `"oteapi.download"`, `"oteapi.filter"`
-* `"oteapi.interfaces.download"`, `"oteapi.interfaces.filter"`
+### Defining entry points
 
-The value for an entrypoint should then be:
+In the following examples, let's imagine we have a package importable in Python through `my_plugin` and contains two download strategies and a single parse strategy:
+
+1. A peer-2-peer download strategy, implemented in a class named `Peer2PeerDownload` importable from `my_plugin.strategies.download.peer_2_peer`.
+2. A MongoDB download strategy, implemented in a class named `MongoRetrieve` importable from `my_plugin.strategies.mongo`.
+3. A MongoDB parse strategy, implemented in a class named `MongoParse` importable from `my_plugin.strategies.mongo`.
+
+There are now various different ways to let the Python environment know of these strategies through entry points.
+
+#### `setup.py`
+
+In the package's `setup.py` file, one can specify entry points.  
+Here, an example snippet is shown using [setuptools](https://setuptools.pypa.io/):
 
 ```python
+# setup.py
+from setuptools import setup
+
 setup(
     # ...,
     entry_points={
-        "oteapi.download_strategy": [
-            "my_plugin.p2p = my_plugin.strategies.download.peer_2_peer",
-            "my_plugin.mongo = my_plugin.strategies.download.mongo_get",
+        "oteapi.download": [
+            "my_plugin.p2p = my_plugin.strategies.download.peer_2_peer:Peer2PeerDownload",
+            "my_plugin.mongo = my_plugin.strategies.mongo:MongoRetrieve",
         ],
+        "oteapi.parse": [
+            "my_plugin.application/vnd.mongo+json = my_plugin.strategies.mongo:MongoParse",
+        ]
     },
 )
 ```
 
-or as part of a YAML/JSON/setup.cfg setup files as such:
+#### YAML/JSON custom files
+
+Use custom files that are later parsed and used in a `setup.py` file.
 
 ```yaml
 entry_points:
-  oteapi.download_strategy:
-  - "my_plugin.p2p = my_plugin.strategies.download.peer_2_peer"
-  - "my_plugin.mongo = my_plugin.strategies.download.mongo_get"
+  oteapi.download:
+  - "my_plugin.p2p = my_plugin.strategies.download.peer_2_peer:Peer2PeerDownload"
+  - "my_plugin.mongo = my_plugin.strategies.mongo:MongoRetrieve"
+  oteapi.parse:
+  - "my_plugin.application/vnd.mongo+json = my_plugin.strategies.mongo:MongoParse"
 ```
 
 ```json
 {
   "entry_points": {
-    "oteapi.download_strategy": [
-      "my_plugin.p2p = my_plugin.strategies.download.peer_2_peer",
-      "my_plugin.mongo = my_plugin.strategies.download.mongo_get"
+    "oteapi.download": [
+      "my_plugin.p2p = my_plugin.strategies.download.peer_2_peer:Peer2PeerDownload",
+      "my_plugin.mongo = my_plugin.strategies.mongo:MongoRetrieve"
+    ],
+    "oteapi.parse": [
+      "my_plugin.application/vnd.mongo+json = my_plugin.strategies.mongo:MongoParse"
     ]
   }
 }
 ```
 
+#### `setup.cfg`/`pyproject.toml`
+
+A more modern approach is to use `setup.cfg` or `pyproject.toml`.
+
 ```ini
 [options.entry_points]
-oteapi.download_strategy =
-    my_plugin.p2p = my_plugin.strategies.download.peer_2_peer
-    my_plugin.mongo = my_plugin.strategies.download.mongo_get
+oteapi.download =
+    my_plugin.p2p = my_plugin.strategies.download.peer_2_peer:Peer2PeerDownload
+    my_plugin.mongo = my_plugin.strategies.mongo:MongoRetrieve
+oteapi.parse =
+    my_plugin.application/vnd.mongo+json = my_plugin.strategies.mongo:MongoParse
 ```
 
-The plugins will then automagically load all installed strategy module plugins, registering the strategies according to the `StrategyFactory` decorator.
+### Syntax and semantics
+
+As seen above, there are a few different syntactical flavors of how to list the entry points.
+However, the "value" stays the same throughout.
+
+#### General Python entry points
+
+The general syntax for entry points is based on `ini` files and parsed using the built-in `configparser` module described [here](https://docs.python.org/3/library/configparser.html#module-configparser).
+Specifically for entry points the nomenclature is the following:
+
+```ini
+[options.entry_points]
+GROUP =
+    NAME = VALUE
+```
+
+The `VALUE` is then further split into: `PACKAGE.MODULE:OBJECT.ATTRIBUTE [EXTRA1, EXTRA2]`.
+
+#### OTEAPI strategy entry points
+
+From the general syntax outlined above, OTEAPI Core then implements rules and requirements regarding the syntax for strategies.
+
+1. A class *MUST* be specified (as an `OBJECT`).
+2. The `NAME` *MUST* consist of exactly two parts: `PACKAGE` and strategy type value in the form of `PACKAGE.STRATEGY_TYPE_VALUE`.
+3. The `GROUP` *MUST* be a valid OTEAPI entry point group, see [Table of entry point strategies](#table-of-entry-point-strategies) for a full list of valid OTEAPI entry point group values.
+
+To understand what the strategy type value should be, see [Table of entry point strategies](#table-of-entry-point-strategies).
+
+### Table of entry point strategies
+
+| Strategy Type Name | Strategy Type Value | Entry Point Group | Documentation Reference |
+|:---:|:---:|:---:|:--- |
+| Download | [`scheme`][oteapi.models.resourceconfig.ResourceConfig.downloadUrl] | `oteapi.download` | [Download strategy](#download-strategy) |
+| Filter | [`filterType`][oteapi.models.filterconfig.FilterConfig.filterType] | `oteapi.filter` | [Filter strategy](#filter-strategy) |
+| Function | [`functionType`][oteapi.models.functionconfig.FunctionConfig.functionType] | `oteapi.function` | [Function strategy](#function-strategy) |
+| Mapping | [`mappingType`][oteapi.models.mappingconfig.MappingConfig.mappingType] | `oteapi.mapping` | [Mapping strategy](#mapping-strategy) |
+| Parse | [`mediaType`][oteapi.models.resourceconfig.ResourceConfig.mediaType] | `oteapi.parse` | [Parse strategy](#parse-strategy) |
+| Resource | [`accessService`][oteapi.models.resourceconfig.ResourceConfig.accessService] | `oteapi.resource` | [Resource strategy](#resource-strategy) |
+| Transformation | [`transformationType`][oteapi.models.transformationconfig.TransformationConfig.transformationType] | `oteapi.transformation` | [Transformation strategy](#transformation-strategy) |
 
 ## Other OTEAPI-related repositories
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,6 +2,13 @@
 
 > Framework for accessing data resources, mapping data models, describing the data to ontologies and perform data transformations
 
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/oteapi-core?logo=pypi)
+![PyPI](https://img.shields.io/pypi/v/oteapi-core?logo=pypi)
+![Codecov master](https://img.shields.io/codecov/c/github/EMMC-ASBL/oteapi-core/master?logo=codecov)
+![CI - Tests](https://github.com/EMMC-ASBL/oteapi-core/actions/workflows/ci_tests.yml/badge.svg?branch=master)
+![GitHub commit activity](https://img.shields.io/github/commit-activity/m/EMMC-ASBL/oteapi-core?logo=github)
+![GitHub last commit](https://img.shields.io/github/last-commit/EMMC-ASBL/oteapi-core?logo=github)
+
 We highly recommend reading this page in [the official documentation](https://emmc-asbl.github.io/oteapi-core).
 
 ## About OTEAPI Core

--- a/oteapi/plugins/entry_points.py
+++ b/oteapi/plugins/entry_points.py
@@ -19,7 +19,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:  # pragma: no cover
     from importlib.metadata import EntryPoint
-    from typing import Any, Dict, Iterator, List, Optional, Set, Tuple, Type, Union
+    from typing import Any, Dict, Iterator, Optional, Set, Tuple, Type, Union
 
     from oteapi.interfaces import IStrategy
 

--- a/tasks.py
+++ b/tasks.py
@@ -179,6 +179,34 @@ def create_docs_index(_):
     replacement_mapping = [
         ("docs/", ""),
         ("(LICENSE)", "(LICENSE.md)"),
+        (
+            "scheme`](oteapi/models/resourceconfig.py)",
+            "scheme`][oteapi.models.resourceconfig.ResourceConfig.downloadUrl]",
+        ),
+        (
+            "mediaType`](oteapi/models/resourceconfig.py)",
+            "mediaType`][oteapi.models.resourceconfig.ResourceConfig.mediaType]",
+        ),
+        (
+            "accessService`](oteapi/models/resourceconfig.py)",
+            "accessService`][oteapi.models.resourceconfig.ResourceConfig.accessService]",
+        ),
+        (
+            "(oteapi/models/filterconfig.py)",
+            "[oteapi.models.filterconfig.FilterConfig.filterType]",
+        ),
+        (
+            "(oteapi/models/functionconfig.py)",
+            "[oteapi.models.functionconfig.FunctionConfig.functionType]",
+        ),
+        (
+            "(oteapi/models/mappingconfig.py)",
+            "[oteapi.models.mappingconfig.MappingConfig.mappingType]",
+        ),
+        (
+            "(oteapi/models/transformationconfig.py)",
+            "[oteapi.models.transformationconfig.TransformationConfig.transformationType]",
+        ),
     ]
 
     for old, new in replacement_mapping:


### PR DESCRIPTION
Closes #91 

Adds badges, but also extends and updates the README concerning entry points and standard strategies.

Go [here](https://github.com/EMMC-ASBL/oteapi-core/tree/cwa/close-91-update-readme#readme) to see the updates in action on GitHub.
To see the updates in action when built as documentation build and serve the documentation locally (assuming you're in the root of the repository):

```shell
pip install -U -e .[docs]  # not needed if already installed with the `dev` extra
mkdocs serve
```

Now open the URL as returned by the last command - should be something like [http://127.0.0.1:8000/oteapi-core/](http://127.0.0.1:8000/oteapi-core/).