### PR TITLE
Store image data in datacache instead of session

### DIFF
--- a/oteapi/models/mappingconfig.py
+++ b/oteapi/models/mappingconfig.py
@@ -1,11 +1,9 @@
 """Pydantic Mapping Configuration Data Model."""
-from typing import Annotated, Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
-from pydantic import Field, conlist
+from pydantic import Field
 
 from oteapi.models.genericconfig import GenericConfig
-
-SemanticTriple = Annotated[list, conlist(str, min_items=3, max_items=3)]
 
 
 class MappingConfig(GenericConfig):
@@ -21,7 +19,7 @@ class MappingConfig(GenericConfig):
             "given as local value/IRI-expansion-pairs."
         ),
     )
-    triples: Optional[List[SemanticTriple]] = Field(
+    triples: Optional[List[Tuple[str, str, str]]] = Field(
         None,
         description="List of semantic triples given as (subject, predicate, object).",
     )

--- a/oteapi/strategies/filter/crop_filter.py
+++ b/oteapi/strategies/filter/crop_filter.py
@@ -45,12 +45,18 @@ class CropImageFilter:
 
     filter_config: CropImageFilterConfig
 
-    def initialize(self, session: "Optional[Dict[str, Any]]" = None) -> SessionUpdate:
+    def initialize(
+        self,
+        session: "Optional[Dict[str, Any]]" = None,
+    ) -> SessionUpdateCropFilter:
         """Initialize strategy and return a dictionary."""
-        return SessionUpdate()
+        return SessionUpdateCropFilter(
+            imagecrop=self.filter_config.configuration.crop,
+        )
 
     def get(
-        self, session: "Optional[Dict[str, Any]]" = None
-    ) -> SessionUpdateCropFilter:
+        self,
+        session: "Optional[Dict[str, Any]]" = None,
+    ) -> SessionUpdate:
         """Execute strategy and return a dictionary"""
-        return SessionUpdateCropFilter(imagecrop=self.filter_config.configuration.crop)
+        return SessionUpdate()

--- a/oteapi/strategies/parse/image.py
+++ b/oteapi/strategies/parse/image.py
@@ -28,8 +28,8 @@ class ImageParserConfig(AttrDict):
         None,
         description="Configuration options for the local data cache.",
     )
-    download_config: Optional[ResourceConfig] = Field(
-        {},
+    download_config: ResourceConfig = Field(
+        ResourceConfig(),
         description="Configurations passed to the downloader.",
     )
     image_key: Optional[str] = Field(
@@ -97,7 +97,7 @@ class SessionUpdateImageParse(SessionUpdate):
         ...,
         description="Image mode. Examples: 'L', 'P', 'RGB', 'RGBA'...",
     )
-    image_palette_key: str = Field(
+    image_palette_key: Optional[str] = Field(
         None,
         description="Datacache key for colour palette if mode is 'P'.",
     )

--- a/oteapi/strategies/parse/image.py
+++ b/oteapi/strategies/parse/image.py
@@ -156,8 +156,9 @@ class ImageDataParseStrategy:
         mime_format = self.parse_config.mediaType.split("/")[1]
         image_format = SupportedFormats[mime_format].value
 
-        # Retrieve image file
+        # Proper download configurations
         conf = self.parse_config.dict()
+        del conf["configuration"]
         if config.download_config:
             conf.update(config.download_config.dict())
         download_config = ResourceConfig(**conf)

--- a/oteapi/strategies/parse/image.py
+++ b/oteapi/strategies/parse/image.py
@@ -1,9 +1,9 @@
 """Strategy class for image/jpg."""
 # pylint: disable=unused-argument
 from enum import Enum
-from io import BytesIO
 from typing import TYPE_CHECKING, Optional, Tuple
 
+import numpy as np
 from PIL import Image
 from pydantic import Field
 from pydantic.dataclasses import dataclass
@@ -22,11 +22,27 @@ class ImageParserConfig(AttrDict):
 
     crop: Optional[Tuple[int, int, int, int]] = Field(
         None,
-        description="Box cropping parameters.",
+        description="Box cropping parameters (left, top, right, bottom).",
     )
     datacache_config: Optional[DataCacheConfig] = Field(
         None,
         description="Configuration options for the local data cache.",
+    )
+    download_config: Optional[ResourceConfig] = Field(
+        {},
+        description="Configurations passed to the downloader.",
+    )
+    image_key: Optional[str] = Field(
+        None,
+        description="Key to use when storing the image data in datacache.",
+    )
+    image_mode: Optional[str] = Field(
+        None,
+        description=(
+            "Pillow mode to convert image into. See "
+            "https://pillow.readthedocs.io/en/stable/handbook/concepts.html "
+            "for details."
+        ),
     )
 
 
@@ -34,7 +50,8 @@ class ImageParserResourceConfig(ResourceConfig):
     """Image parse strategy resource config."""
 
     configuration: ImageParserConfig = Field(
-        ImageParserConfig(), description="Image parse strategy-specific configuration."
+        ImageParserConfig(),
+        description="Image parse strategy-specific configuration.",
     )
     mediaType: str = Field(
         ...,
@@ -48,28 +65,65 @@ class ImageParserResourceConfig(ResourceConfig):
     )
 
 
-class SupportedFormat(Enum):
+class SupportedFormats(Enum):
     """Supported formats for `ImageDataParseStrategy`."""
 
-    JPEG = "JPEG"
-    JPEG2000 = "JPEG2000"
-    PNG = "PNG"
-    GIF = "GIF"
-    TIFF = "TIFF"
-    EPS = "EPS"
+    jpeg = "JPEG"
+    jpg = "JPEG"
+    jp2 = "JPEG2000"
+    png = "PNG"
+    gif = "GIF"
+    tiff = "TIFF"
+    tif = "TIFF"
+    eps = "EPS"
 
 
 class SessionUpdateImageParse(SessionUpdate):
-    """Configuration model for ImageParse."""
+    """Configuration model for ImageParse.
 
-    content: bytes = Field(..., description="Parsed output from ImageParse.")
-    format: SupportedFormat = Field(..., description="The format of the parsed image.")
-    cropped: bool = Field(..., description="Whether or not the image has been cropped.")
+    For
+      - image_mode
+      - image_palette
+      - image_info
+
+    see [Pillow handbook](https://pillow.readthedocs.io/en/stable/handbook/concepts.html) for more details.
+    """
+
+    image_key: str = Field(
+        ...,
+        description="Key with which the image content is stored in datacache.",
+    )
+    image_size: Tuple[int, int] = Field(
+        ...,
+        description="Image size (width, height).",
+    )
+    image_mode: str = Field(
+        ...,
+        description="Image mode. Examples: 'L', 'P', 'RGB', 'RGBA'...",
+    )
+    image_palette_key: str = Field(
+        None,
+        description="Datacache key for colour palette if mode is 'P'.",
+    )
+    image_info: dict = Field(
+        {},
+        description="Additional information about the image.",
+    )
 
 
 @dataclass
 class ImageDataParseStrategy:
     """Parse strategy for images.
+
+    This strategy uses Pillow to read a raw image from the data cache,
+    converts it into a NumPy array and stores the new array in the
+    data cache.
+
+    It also support simple cropping and image conversions.
+
+    The key to the new array and other metadata is stored in the session. See
+    [`SessionUpdateImageParse`][oteapi.strategies.parse.image.SessionUpdateImageParse]
+    for more info.
 
     **Registers strategies**:
 
@@ -93,27 +147,44 @@ class ImageDataParseStrategy:
         self, session: "Optional[Dict[str, Any]]" = None
     ) -> SessionUpdateImageParse:
         """Execute the strategy."""
-        if session:
-            self._use_filters(session)
-        session = session if session else {}
+        if not session:
+            session = {}
+
+        config = self.parse_config.configuration
+        crop = config.crop if config.crop else session.get("imagecrop")
 
         mime_format = self.parse_config.mediaType.split("/")[1]
-        image_format = self._map_mime_to_format()
+        image_format = SupportedFormats[mime_format].value
 
         # Retrieve image file
-        download_config = ResourceConfig(**self.parse_config.dict())
-        del download_config.configuration
+        conf = self.parse_config.dict()
+        if config.download_config:
+            conf.update(config.download_config.dict())
+        download_config = ResourceConfig(**conf)
+
         downloader = create_strategy("download", download_config)
         session.update(downloader.initialize(session))
-        cache_key = downloader.get(session).get("key", "")
 
-        cache = DataCache(self.parse_config.configuration.datacache_config)
+        downloader = create_strategy("download", download_config)
+        output = downloader.get(session)
+        session.update(output)
+
+        if config.datacache_config and config.datacache_config.accessKey:
+            cache_key = config.datacache_config.accessKey
+        elif "key" in output:
+            cache_key = output["key"]
+        else:
+            RuntimeError("no datacache key provided to downloaded content")
+
+        cache = DataCache(config.datacache_config)
 
         # Treat image according to filter values
         with cache.getfile(cache_key, suffix=mime_format) as filename:
-            image = Image.open(filename, formats=[image_format]).crop(
-                self.parse_config.configuration.crop
-            )
+            image = Image.open(filename, formats=[image_format])
+        if crop:
+            image = image.crop(crop)
+        if config.image_mode:
+            image = image.convert(mode=config.image_mode)
 
         if image_format == "GIF":
             if image.info.get("version", b"").startswith(b"GIF"):
@@ -121,25 +192,21 @@ class ImageDataParseStrategy:
                     {"version": image.info.get("version", b"")[len(b"GIF") :]}
                 )
 
-        # Return parsed and treated image
-        image_content = BytesIO()
-        image.save(image_content, format=image_format)
+        # Use the buffer protocol to store the image in the datacache
+        data = np.asarray(image)
+        image_key = cache.add(data, key=config.image_key, tag=str(id(session)))
+
+        if image.mode == "P":
+            image_palette_key = cache.add(
+                np.asarray(image.getpalette()), tag=str(id(session))
+            )
+        else:
+            image_palette_key = None
+
         return SessionUpdateImageParse(
-            content=image_content.getvalue(),
-            format=image_format,
-            cropped=bool(self.parse_config.configuration.crop),
+            image_key=image_key,
+            image_size=image.size,
+            image_mode=image.mode,
+            image_palette_key=image_palette_key,
+            image_info=image.info,
         )
-
-    def _use_filters(self, session: "Dict[str, Any]") -> None:
-        """Update `config` according to filter values found in the session."""
-        if "imagecrop" in session and not self.parse_config.configuration.crop:
-            # Use CropFilter available in session
-            self.parse_config.configuration.crop = session["imagecrop"]
-
-    def _map_mime_to_format(self) -> str:
-        """Return mapped Pillow-understandable format."""
-        image_format = self.parse_config.mediaType.split("/")[1]
-        return {
-            "jpg": "JPEG",
-            "jp2": "JPEG2000",
-        }.get(image_format, image_format.upper())

--- a/oteapi/strategies/parse/image.py
+++ b/oteapi/strategies/parse/image.py
@@ -150,7 +150,7 @@ class ImageDataParseStrategy:
         crop = config.crop if config.crop else session.get("imagecrop")
 
         mime_format = self.parse_config.mediaType.split("/")[1]
-        image_format = SupportedFormats[mime_format].value
+        image_format = SupportedFormat[mime_format].value
 
         # Proper download configurations
         conf = self.parse_config.dict()

--- a/oteapi/strategies/parse/image.py
+++ b/oteapi/strategies/parse/image.py
@@ -182,10 +182,10 @@ class ImageDataParseStrategy:
         # Treat image according to filter values
         with cache.getfile(cache_key, suffix=mime_format) as filename:
             image = Image.open(filename, formats=[image_format])
-        if crop:
-            image = image.crop(crop)
-        if config.image_mode:
-            image = image.convert(mode=config.image_mode)
+            if crop:
+                image = image.crop(crop)
+            if config.image_mode:
+                image = image.convert(mode=config.image_mode)
 
         if image_format == "GIF":
             if image.info.get("version", b"").startswith(b"GIF"):

--- a/oteapi/strategies/parse/image.py
+++ b/oteapi/strategies/parse/image.py
@@ -28,8 +28,8 @@ class ImageParserConfig(AttrDict):
         None,
         description="Configuration options for the local data cache.",
     )
-    download_config: ResourceConfig = Field(
-        ResourceConfig(),
+    download_config: Optional[ResourceConfig] = Field(
+        None,
         description="Configurations passed to the downloader.",
     )
     image_key: Optional[str] = Field(
@@ -154,7 +154,7 @@ class ImageDataParseStrategy:
 
         # Proper download configurations
         conf = self.parse_config.dict()
-        conf["configuration"] = config.download_config
+        conf["configuration"] = config.download_config or {}
         download_config = ResourceConfig(**conf)
 
         downloader = create_strategy("download", download_config)

--- a/oteapi/strategies/parse/image.py
+++ b/oteapi/strategies/parse/image.py
@@ -215,7 +215,7 @@ class ImageDataParseStrategy:
                     if isinstance(val, (str, int, float, type(None), bool, tuple, list))
                 }
             else:
-                image_info = None
+                image_info = {}
 
             session_update = SessionUpdateImageParse(
                 image_key=image_key,

--- a/oteapi/strategies/parse/image.py
+++ b/oteapi/strategies/parse/image.py
@@ -153,9 +153,8 @@ class ImageDataParseStrategy:
         image_format = SupportedFormat[mime_format].value
 
         # Proper download configurations
-        conf = self.parse_config.dict()
-        conf["configuration"] = config.download_config
-        download_config = ResourceConfig(**conf)
+        download_config = self.parse_config.copy()
+        download_config.configuration = config.download_config
 
         downloader = create_strategy("download", download_config)
         session.update(downloader.initialize(session))

--- a/oteapi/strategies/parse/image.py
+++ b/oteapi/strategies/parse/image.py
@@ -153,8 +153,9 @@ class ImageDataParseStrategy:
         image_format = SupportedFormat[mime_format].value
 
         # Proper download configurations
-        download_config = self.parse_config.copy()
-        download_config.configuration = config.download_config
+        conf = self.parse_config.dict()
+        conf["configuration"] = config.download_config
+        download_config = ResourceConfig(**conf)
 
         downloader = create_strategy("download", download_config)
         session.update(downloader.initialize(session))

--- a/oteapi/strategies/parse/image.py
+++ b/oteapi/strategies/parse/image.py
@@ -65,7 +65,7 @@ class ImageParserResourceConfig(ResourceConfig):
     )
 
 
-class SupportedFormats(Enum):
+class SupportedFormat(Enum):
     """Supported formats for `ImageDataParseStrategy`."""
 
     jpeg = "JPEG"
@@ -81,17 +81,13 @@ class SupportedFormats(Enum):
 class SessionUpdateImageParse(SessionUpdate):
     """Configuration model for ImageParse.
 
-    For
-      - image_mode
-      - image_palette
-      - image_info
-
-    see [Pillow handbook](https://pillow.readthedocs.io/en/stable/handbook/concepts.html) for more details.
+    See [Pillow handbook](https://pillow.readthedocs.io/en/stable/handbook/concepts.html) for more details
+    on `image_mode`, `image_palette`, and `image_info`.
     """
 
     image_key: str = Field(
         ...,
-        description="Key with which the image content is stored in datacache.",
+        description="Key with which the image content is stored in the data cache.",
     )
     image_size: Tuple[int, int] = Field(
         ...,
@@ -119,7 +115,7 @@ class ImageDataParseStrategy:
     converts it into a NumPy array and stores the new array in the
     data cache.
 
-    It also support simple cropping and image conversions.
+    It also supports simple cropping and image conversions.
 
     The key to the new array and other metadata is stored in the session. See
     [`SessionUpdateImageParse`][oteapi.strategies.parse.image.SessionUpdateImageParse]
@@ -173,7 +169,7 @@ class ImageDataParseStrategy:
         elif "key" in output:
             cache_key = output["key"]
         else:
-            RuntimeError("no datacache key provided to downloaded content")
+            RuntimeError("No data cache key provided to the downloaded content")
 
         cache = DataCache(config.datacache_config)
 

--- a/oteapi/strategies/parse/image.py
+++ b/oteapi/strategies/parse/image.py
@@ -158,9 +158,7 @@ class ImageDataParseStrategy:
 
         # Proper download configurations
         conf = self.parse_config.dict()
-        del conf["configuration"]
-        if config.download_config:
-            conf.update(config.download_config.dict())
+        conf["configuration"] = config.download_config
         download_config = ResourceConfig(**conf)
 
         downloader = create_strategy("download", download_config)

--- a/oteapi/strategies/parse/image.py
+++ b/oteapi/strategies/parse/image.py
@@ -206,12 +206,23 @@ class ImageDataParseStrategy:
             else:
                 image_palette_key = None
 
+            # The session must be json serialisable - filter out all
+            # non-json serialisable fields in image.info
+            if image.info:
+                image_info = {
+                    key: val
+                    for key, val in image.info.items()
+                    if isinstance(val, (str, int, float, type(None), bool, tuple, list))
+                }
+            else:
+                image_info = None
+
             session_update = SessionUpdateImageParse(
                 image_key=image_key,
                 image_size=image.size,
                 image_mode=image.mode,
                 image_palette_key=image_palette_key,
-                image_info=image.info,
+                image_info=image_info,
             )
 
             # Explicitly close the image to avoid crashes on Windows

--- a/tests/strategies/filter/test_crop_filter.py
+++ b/tests/strategies/filter/test_crop_filter.py
@@ -43,8 +43,9 @@ def test_crop_filter(static_files: "Path") -> None:
 
     cache = DataCache()
     image_key = session["image_key"]
-    data = cache.get(image_key)
 
-    assert data.shape == (400, 700, 3)
-
-    del cache[image_key]
+    try:
+        data = cache.get(image_key)
+        assert data.shape == (400, 700, 3)
+    finally:
+        del cache[image_key]

--- a/tests/strategies/filter/test_crop_filter.py
+++ b/tests/strategies/filter/test_crop_filter.py
@@ -34,7 +34,7 @@ def test_crop_filter(static_files: "Path") -> None:
     }
     image_parser: "IParseStrategy" = ImageDataParseStrategy(image_config)
 
-    # Run "pipeline"
+    # Run pipeline = image_parser > crop_filter
     session = {}
     session.update(crop_filter.initialize(session))
     session.update(image_parser.initialize(session))

--- a/tests/strategies/parse/test_image.py
+++ b/tests/strategies/parse/test_image.py
@@ -82,6 +82,7 @@ def test_image(
     assert reference_file.exists(), f"Test file not found at {reference_file} !"
 
     for itest in range(2):
+        print(f"itest={itest}")
         config = {
             "downloadUrl": sample_file.as_uri(),
             "mediaType": f"image/{image_format}",
@@ -98,6 +99,7 @@ def test_image(
         cache = DataCache()
         image_key = session["image_key"]
         data = cache.get(image_key)
+        del cache[image_key]
 
         if crop:
             mode = session["image_mode"]

--- a/tests/strategies/parse/test_image.py
+++ b/tests/strategies/parse/test_image.py
@@ -98,8 +98,10 @@ def test_image(
 
         cache = DataCache()
         image_key = session["image_key"]
-        data = cache.get(image_key)
-        del cache[image_key]
+        try:
+            data = cache.get(image_key)
+        finally:
+            del cache[image_key]
 
         if crop:
             mode = session["image_mode"]

--- a/tests/strategies/parse/test_image.py
+++ b/tests/strategies/parse/test_image.py
@@ -89,10 +89,10 @@ def test_image(
         }
         session = {"imagecrop": crop} if crop and itest == 1 else {}
 
-        parser = ImageDataParseStrategy(parse_config=config)
+        parser: "IParseStrategy" = ImageDataParseStrategy(parse_config=config)
         session.update(parser.initialize(session))
 
-        parser = ImageDataParseStrategy(parse_config=config)
+        parser: "IParseStrategy" = ImageDataParseStrategy(parse_config=config)
         session.update(parser.get(session))
 
         cache = DataCache()

--- a/tests/strategies/parse/test_image.py
+++ b/tests/strategies/parse/test_image.py
@@ -36,7 +36,11 @@ def test_image(
     static_files: "Path",
 ) -> None:
     """Test parsing an image format."""
-    from oteapi.strategies.parse.image import ImageDataParseStrategy, SupportedFormat
+    import numpy as np
+    from PIL import Image
+
+    from oteapi.datacache import DataCache
+    from oteapi.strategies.parse.image import ImageDataParseStrategy
 
     if image_format == "eps":
         # Skip if Ghostscript is not installed
@@ -70,8 +74,6 @@ def test_image(
         if failed:
             pytest.skip("Could not find Ghostscript on the system.")
 
-    mime_to_format = {"jpg": "jpeg", "jp2": "jpeg2000"}
-
     sample_file = static_files / filename
     reference_file = (
         static_files / filename_cropped if filename_cropped else static_files / filename
@@ -79,28 +81,29 @@ def test_image(
     assert sample_file.exists(), f"Test file not found at {sample_file} !"
     assert reference_file.exists(), f"Test file not found at {reference_file} !"
 
-    for config_parse_test in range(2):
-        print(f"config_parse_test={config_parse_test}")
-
+    for itest in range(2):
         config = {
             "downloadUrl": sample_file.as_uri(),
             "mediaType": f"image/{image_format}",
-            "configuration": {"crop": crop} if crop and config_parse_test == 0 else {},
+            "configuration": {"crop": crop} if crop and itest == 0 else {},
         }
-        parser: "IParseStrategy" = ImageDataParseStrategy(parse_config=config)
+        session = {"imagecrop": crop} if crop and itest == 1 else {}
 
-        session = parser.initialize(
-            {"imagecrop": crop} if crop and config_parse_test == 1 else None
-        )
-        session = parser.get(
-            {"imagecrop": crop} if crop and config_parse_test == 1 else session
-        )
+        parser = ImageDataParseStrategy(parse_config=config)
+        session.update(parser.initialize(session))
 
-        assert (
-            session.get("cropped", False) if crop else not session.get("cropped", False)
-        )
-        assert (
-            session.get("format", SupportedFormat).value
-            == mime_to_format.get(image_format, image_format).upper()
-        )
-        assert session.get("content", b"") == reference_file.read_bytes()
+        parser = ImageDataParseStrategy(parse_config=config)
+        session.update(parser.get(session))
+
+        cache = DataCache()
+        image_key = session["image_key"]
+        data = cache.get(image_key)
+
+        if crop:
+            mode = session["image_mode"]
+            assert data.shape == (400, 700) if mode == "P" else (400, 700, 3)
+
+    if filename_cropped and image_format in ("png", "gif", "eps", "tiff"):
+        cropped = Image.open(reference_file, formats=[image_format])
+        arr = np.asarray(cropped)
+        assert np.all(data == arr)


### PR DESCRIPTION
fixed #107 

Converts image to numpy array and stores it datacache instead of session.
The returned payload is now small and useful.

Additionally:
- cleaned up the image parser and corresponding tests
- provide proper download configurations (via the parser)
- added image_mode option to allow conversion to desired image mode 
- return relevant metadata about the image (not its source), like size, mode, palette, and an info dict
- explicitly closes the Pillow image when done with it, to avoid crash on Windows
- the change in mappingconfig.py is because pydantic does not support typing.Annotated

This PR affects the image parse strategy in oteapi-dlite. Merge oteapi-dlite PR 18 together with this one.