### PR TITLE
Corrected the sql_query_filter.

### DIFF
--- a/oteapi/strategies/filter/sql_query_filter.py
+++ b/oteapi/strategies/filter/sql_query_filter.py
@@ -35,10 +35,13 @@ class SQLQueryFilter:
 
     filter_config: SqlQueryFilterConfig
 
-    def initialize(self, session: "Optional[Dict[str, Any]]" = None) -> SessionUpdate:
+    def initialize(
+        self,
+        session: "Optional[Dict[str, Any]]" = None,
+    ) -> SessionUpdateSqlQuery:
         """Initialize strategy."""
-        return SessionUpdate()
-
-    def get(self, session: "Optional[Dict[str, Any]]" = None) -> SessionUpdateSqlQuery:
-        """Execute strategy and return a dictionary."""
         return SessionUpdateSqlQuery(sqlquery=self.filter_config.query)
+
+    def get(self, session: "Optional[Dict[str, Any]]" = None) -> SessionUpdate:
+        """Execute strategy and return a dictionary."""
+        return SessionUpdate()


### PR DESCRIPTION
Filters are intended to be placed after the strategy they work on in the pipeline.

Lets agree on the preferred way to set up pipelines. This PR implements the original idea.