### PR TITLE
Fix deleting entries in AttrDict

### DIFF
--- a/oteapi/models/genericconfig.py
+++ b/oteapi/models/genericconfig.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Iterable, Mapping
 from pydantic import BaseModel, Field
 from pydantic.fields import Undefined
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from typing import Any, Optional, Tuple, Union
 
 

--- a/oteapi/models/genericconfig.py
+++ b/oteapi/models/genericconfig.py
@@ -17,34 +17,31 @@ class AttrDict(BaseModel, Mapping):
         return self.__dict__.__contains__(name)
 
     def __delitem__(self, key: str) -> None:
-        """Enable deletion access through subscription."""
-        if key in dir(self):
-            self.__delattr__(key)
+        """Enable deletion access through subscription.
+
+        If the item is a pydantic field, reset it and remove it from the set of set
+        fields. Otherwise, delete the attribute.
+
+        """
+        if key in self.__dict__:
             if key in self.__fields__:
-                del self.__fields__[key]
+                # Reset field to default and remove from set of set fields
+                setattr(self, key, self.__fields__[key].default)
                 self.__fields_set__.remove(key)  # pylint: disable=no-member
+            else:
+                self.__delattr__(key)
         else:
             raise KeyError(key)
 
     def __getitem__(self, key: str) -> "Any":
         """Enable read access through subscription."""
-        if key in dir(self):
+        if key in self.__dict__:
             return getattr(self, key)
         raise KeyError(key)
 
-    def __setattr__(self, name: str, value: "Any") -> None:
-        """Extend BaseModel.__setattr__ with type-checking."""
-        if name in self.__dict__ and self.__dict__[name]:
-            target_type = type(self.__dict__[name])
-            if not isinstance(value, target_type):
-                raise TypeError(
-                    "Mapped value must be subclass of " + target_type.__name__
-                )
-        super().__setattr__(name, value)
-
     def __setitem__(self, key: str, value: "Any") -> None:
         """Enable write access through subscription."""
-        self.__setattr__(key, value)
+        setattr(self, key, value)
 
     def __len__(self):
         """Return number of items."""
@@ -71,6 +68,7 @@ class AttrDict(BaseModel, Mapping):
         return self.__dict__.get(key, default)
 
     def __ne__(self, other: "Any") -> bool:
+        """Implement the != operator."""
         if isinstance(other, BaseModel):
             return self.dict() != other.dict()
         return self.dict() != other
@@ -81,6 +79,9 @@ class AttrDict(BaseModel, Mapping):
         """MutableMapping `update`-method."""
         if other and isinstance(other, (dict, Mapping)):
             for key, value in other.items():
+                setattr(self, key, value)
+        elif other and isinstance(other, BaseModel):
+            for key, value in other.dict().items():
                 setattr(self, key, value)
         elif other and isinstance(other, Iterable):
             for entry in other:

--- a/oteapi/models/resourceconfig.py
+++ b/oteapi/models/resourceconfig.py
@@ -5,7 +5,7 @@ from pydantic import AnyUrl, Field, root_validator
 
 from oteapi.models.genericconfig import GenericConfig
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from typing import Any, Dict
 
 

--- a/oteapi/utils/paths.py
+++ b/oteapi/utils/paths.py
@@ -6,7 +6,7 @@ from urllib.parse import ParseResult, urlparse
 
 from pydantic import AnyUrl
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from typing import Union
 
 

--- a/tests/models/test_genericconfig.py
+++ b/tests/models/test_genericconfig.py
@@ -1,5 +1,5 @@
 """Tests for `oteapi.models.genericconfig`"""
-# pylint: disable=no-member,pointless-statement,disallowed-name
+# pylint: disable=no-member
 from typing import TYPE_CHECKING
 
 import pytest
@@ -29,12 +29,13 @@ def generic_config() -> "CustomConfig":
         """A custom AttrDict class to use as `configuration` in CustomConfig."""
 
         string: str = Field("")
+        required_string: str = Field(...)
 
     class CustomConfig(GenericConfig):
         """A CustomConfig class."""
 
         configuration: CustomConfiguration = Field(
-            CustomConfiguration(),
+            CustomConfiguration(required_string=""),
             description=GenericConfig.__fields__[
                 "configuration"
             ].field_info.description,
@@ -45,6 +46,7 @@ def generic_config() -> "CustomConfig":
             "float": 3.14,
             "integer": 5,
             "string": "foo",
+            "required_string": "bar",
         }
     )
 
@@ -72,7 +74,9 @@ def test_attribute_get_item_fail(generic_config: "CustomConfig") -> None:
     non_existent_key = "non_existent_key"
     assert non_existent_key not in generic_config.configuration
     with pytest.raises(KeyError):
-        generic_config.configuration[non_existent_key]
+        generic_config.configuration[  # pylint: disable=pointless-statement
+            non_existent_key
+        ]
 
 
 def test_attribute_set(generic_config: "CustomConfig") -> None:
@@ -121,6 +125,8 @@ def test_attribute_del_item(generic_config: "CustomConfig") -> None:
 
 def test_attribute_del_item_fail(generic_config: "CustomConfig") -> None:
     """Ensure KeyError is raised if key does not exist in AttrDict."""
+    from pydantic import ValidationError
+
     non_existent_key = "non_existant_key"
     assert non_existent_key not in generic_config.configuration
     with pytest.raises(KeyError):
@@ -131,18 +137,22 @@ def test_attribute_del_item_fail(generic_config: "CustomConfig") -> None:
     del generic_config.configuration["string"]
     del generic_config.configuration["string"]
 
+    # Ensure `ValidationError` is raised if deleting a "required" field.
+    with pytest.raises(ValidationError):
+        del generic_config.configuration["required_string"]
+
 
 def test_attribute_ne(generic_config: "CustomConfig") -> None:
     """Test configuration.__ne__()."""
     from pydantic import BaseModel
 
-    class Foo(BaseModel):
-        """Foo pydantic model."""
+    class Test(BaseModel):
+        """Test pydantic model."""
 
-        foo: str
+        test: str
 
-    assert generic_config.configuration != Foo(foo="foo")
-    assert generic_config.configuration != {"foo": "foo"}
+    assert generic_config.configuration != Test(test="test")
+    assert generic_config.configuration != {"test": "test"}
     assert generic_config.configuration != 2
 
     copy_config = generic_config.configuration.copy(deep=True)

--- a/tests/models/test_genericconfig.py
+++ b/tests/models/test_genericconfig.py
@@ -1,15 +1,25 @@
 """Tests for `oteapi.models.genericconfig`"""
-# pylint: disable=no-member
+# pylint: disable=no-member,pointless-statement,disallowed-name
 from typing import TYPE_CHECKING
 
 import pytest
 
 if TYPE_CHECKING:
-    from oteapi.models.genericconfig import GenericConfig
+    from oteapi.models.genericconfig import AttrDict, GenericConfig
+
+    class CustomConfiguration(AttrDict):
+        """A custom AttrDict class to use as `configuration` in CustomConfig."""
+
+        string: str
+
+    class CustomConfig(GenericConfig):
+        """A CustomConfig class."""
+
+        configuration: CustomConfiguration
 
 
 @pytest.fixture
-def generic_config() -> "GenericConfig":
+def generic_config() -> "CustomConfig":
     """Return a usable `GenericConfig` for test purposes."""
     from pydantic import Field
 
@@ -52,12 +62,20 @@ def test_subclass_description() -> None:
     assert instance.description == instance.__doc__
 
 
-def test_attribute_get_item(generic_config: "GenericConfig") -> None:
+def test_attribute_get_item(generic_config: "CustomConfig") -> None:
     """Test configuration.__getitem__."""
     assert generic_config.configuration["integer"] == 5
 
 
-def test_attribute_set(generic_config: "GenericConfig") -> None:
+def test_attribute_get_item_fail(generic_config: "CustomConfig") -> None:
+    """Ensure KeyError is raised for a non-existent key."""
+    non_existent_key = "non_existent_key"
+    assert non_existent_key not in generic_config.configuration
+    with pytest.raises(KeyError):
+        generic_config.configuration[non_existent_key]
+
+
+def test_attribute_set(generic_config: "CustomConfig") -> None:
     """Test configuration.__setitem__, and thus also configuration.__setattr__.
 
     Assign different values to test dynamic type-casting.
@@ -75,15 +93,60 @@ def test_attribute_set(generic_config: "GenericConfig") -> None:
     assert generic_config.configuration["float"] == "0"
 
 
-def test_attribute_contains(generic_config: "GenericConfig") -> None:
+def test_attribute_contains(generic_config: "CustomConfig") -> None:
     """Test confguration.__contains__."""
     assert "float" in generic_config.configuration
 
 
-def test_attribute_del_item(generic_config: "GenericConfig") -> None:
+def test_attribute_del_item(generic_config: "CustomConfig") -> None:
     """Test configuration.__delitem__."""
     del generic_config.configuration["float"]
     assert "float" not in generic_config.configuration
+
+    # "string" is defined as a pydantic model field.
+    # This means it should not be deleted, but reset to its default value
+    # and removed from the set of set fields.
+    generic_config.configuration["string"] = "my secret string"
+    assert generic_config.configuration.string == "my secret string"
+    assert "string" in generic_config.configuration.__fields_set__
+
+    del generic_config.configuration["string"]
+    assert "string" in generic_config.configuration
+    assert (
+        generic_config.configuration.string
+        == generic_config.configuration.__fields__["string"].default
+    )
+    assert "string" not in generic_config.configuration.__fields_set__
+
+
+def test_attribute_del_item_fail(generic_config: "CustomConfig") -> None:
+    """Ensure KeyError is raised if key does not exist in AttrDict."""
+    non_existent_key = "non_existant_key"
+    assert non_existent_key not in generic_config.configuration
+    with pytest.raises(KeyError):
+        del generic_config.configuration[non_existent_key]
+
+    # Make sure deleting a pydantic field does not fully delete it
+    # and hence does not raise KeyError.
+    del generic_config.configuration["string"]
+    del generic_config.configuration["string"]
+
+
+def test_attribute_ne(generic_config: "CustomConfig") -> None:
+    """Test configuration.__ne__()."""
+    from pydantic import BaseModel
+
+    class Foo(BaseModel):
+        """Foo pydantic model."""
+
+        foo: str
+
+    assert generic_config.configuration != Foo(foo="foo")
+    assert generic_config.configuration != {"foo": "foo"}
+    assert generic_config.configuration != 2
+
+    copy_config = generic_config.configuration.copy(deep=True)
+    assert (generic_config.configuration != copy_config) is False
 
 
 def test_attrdict() -> None:

--- a/tests/models/test_genericconfig.py
+++ b/tests/models/test_genericconfig.py
@@ -163,9 +163,17 @@ def test_attrdict() -> None:
 
 def test_attrdict_update() -> None:
     """Test supplying `AttrDict.update()` with different (valid) types."""
-    from pydantic import Field
+    from pydantic import BaseModel, Field
 
     from oteapi.models.genericconfig import AttrDict
+
+    class Foo(BaseModel):
+        """Foo pydantic model."""
+
+        class Config:
+            """Foo pydantic config."""
+
+            extra = "allow"
 
     class SubAttrDict(AttrDict):
         """1st level sub-class of AttrDict."""
@@ -180,13 +188,17 @@ def test_attrdict_update() -> None:
     final_data = data.copy()
     final_data.update(update_data)
 
-    testing_types = (dict, AttrDict, SubAttrDict, SubSubAttrDict)
+    testing_types = dict, AttrDict, SubAttrDict, SubSubAttrDict
+    non_update_method_testing_types = testing_types + (Foo,)
     for original_type in testing_types:
-        for other_type in testing_types:
+        for other_type in non_update_method_testing_types:
             original = original_type(**data)
             other = other_type(**update_data)
             original.update(other)
-            assert {**original} == final_data
+            assert {**original} == final_data, (
+                f"original type: {original_type.__name__}, "
+                f"other type: {other_type.__name__}"
+            )
 
 
 def test_attrdict_pop_popitem() -> None:

--- a/tests/models/test_genericconfig.py
+++ b/tests/models/test_genericconfig.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 @pytest.fixture
 def generic_config() -> "CustomConfig":
-    """Return a usable `GenericConfig` for test purposes."""
+    """Return a usable `CustomConfig` for test purposes."""
     from pydantic import Field
 
     from oteapi.models.genericconfig import AttrDict, GenericConfig


### PR DESCRIPTION
# Description:
<!-- Summary of change, including the issue to be addressed. -->
Fixes #143 

When deleting entries in AttrDict they should be completely removed from the `__dict__` in case the entry is not a defined pydantic field, otherwise it should be reset to the default value and removed from the set of set fields.

Fix `update()` method to check for a pydantic model (after checking for a `dict` or `Mapping`) and then convert the model to a `dict`.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [X] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
