### PR TITLE
191 psycopg2postgresql datasource strategy

### DIFF
--- a/docs/api_reference/strategies/resource/.pages
+++ b/docs/api_reference/strategies/resource/.pages
@@ -1,0 +1,1 @@
+title: "resource"

--- a/docs/api_reference/strategies/resource/application_vnd_postgres.md
+++ b/docs/api_reference/strategies/resource/application_vnd_postgres.md
@@ -1,0 +1,3 @@
+# application_vnd_postgres
+
+::: oteapi.strategies.resource.application_vnd_postgres

--- a/oteapi/strategies/filter/sql_query_filter.py
+++ b/oteapi/strategies/filter/sql_query_filter.py
@@ -12,7 +12,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 
 class SqlQueryFilterConfig(FilterConfig):
-    """SQLite query filter strategy filter config."""
+    """SQL query filter strategy filter config."""
 
     filterType: str = Field(
         "filter/sql",

--- a/oteapi/strategies/parse/application_vnd_postgres.py
+++ b/oteapi/strategies/parse/application_vnd_postgres.py
@@ -1,0 +1,108 @@
+"""Strategy class for application/vnd.postgresql"""
+# pylint: disable=unused-argument
+import psycopg
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional
+
+from pydantic import Field
+from pydantic.dataclasses import dataclass
+
+from oteapi.datacache import DataCache
+from oteapi.models import AttrDict, DataCacheConfig, ResourceConfig, SessionUpdate
+from oteapi.plugins import create_strategy
+
+if TYPE_CHECKING:  # pragma: no cover
+    from typing import Any, Dict
+
+
+# NOTE: common to all SQL configs
+class PostgresParseConfig(AttrDict):
+    """Configuration data model for
+    [`PostgresParseStrategy`][oteapi.strategies.parse.application_vnd_postgres.PostgresParseStrategy]."""
+
+    sqlquery: str = Field("", description="A SQL query string.")
+    datacache_config: Optional[DataCacheConfig] = Field(
+        None,
+        description="Configuration options for the local data cache.",
+    )
+
+
+class PostgresParserResourceConfig(ResourceConfig):
+    """Postgres parse strategy resource config."""
+
+    mediaType: str = Field(
+        "application/vnd.postgres",
+        const=True,
+        description=ResourceConfig.__fields__["mediaType"].field_info.description,
+    )
+    configuration: PostgresParseConfig = Field(
+        PostgresParseConfig(), description="Postgres parse strategy-specific configuration."
+    )
+
+
+def create_connection(conn_config: dict) -> psycopg.Connection:
+    """Create a database connection to Postgres database.
+
+    Parameters:
+        pos: Full path to Postgres database file.
+
+    Raises:
+        psycopg.Error: If a DB connection cannot be made.
+
+    Returns:
+        Connection object.
+
+    """
+    try:
+        return psycopg.connect(**conn_config)
+    except psycopg.Error as exc:
+        raise psycopg.Error("Could not connect to given Postgres DB.") from exc
+
+
+class SessionUpdatePostgresParse(SessionUpdate):
+    """Configuration model for PostgresParse."""
+
+    result: list = Field(..., description="List of results from the query.")
+
+
+@dataclass
+class PostgresParseStrategy:
+    """Parse strategy for Postgres.
+
+    **Registers strategies**:
+
+    - `("mediaType", "application/vnd.postgres")`
+
+    Purpose of this strategy: Connect to a postgres DB and run a
+    SQL query on the database to return all relevant rows.
+
+    """
+
+    parse_config: PostgresParserResourceConfig
+
+    def initialize(self, session: "Optional[Dict[str, Any]]" = None) -> SessionUpdate:
+        """Initialize strategy."""
+        return SessionUpdate()
+
+    def get(
+        self, session: "Optional[Dict[str, Any]]" = None
+    ) -> SessionUpdatePostgresParse:
+        """Parse Postgres query responses."""
+        if session:
+            self._use_filters(session)
+        session = session if session else {}
+
+        # Not yet sure how to set up the connection config...
+        conn_config = self.parse_config.copy()['conn_config']
+
+        connection = create_connection(conn_config)
+        cursor = connection.cursor()
+        result = cursor.execute(self.parse_config.configuration.sqlquery).fetchall()
+        connection.close()
+        return SessionUpdatePostgresParse(result=result)
+
+    def _use_filters(self, session: "Dict[str, Any]") -> None:
+        """Update `config` according to filter values found in the session."""
+        if "sqlquery" in session and not self.parse_config.configuration.sqlquery:
+            # Use SQL query available in session
+            self.parse_config.configuration.sqlquery = session["sqlquery"]

--- a/oteapi/strategies/resource/application_vnd_postgres.py
+++ b/oteapi/strategies/resource/application_vnd_postgres.py
@@ -9,38 +9,45 @@ from pydantic.dataclasses import dataclass
 
 from oteapi.datacache import DataCache
 from oteapi.models import AttrDict, DataCacheConfig, ResourceConfig, SessionUpdate
+from oteapi.models.resourceconfig import HostlessAnyUrl
 from oteapi.plugins import create_strategy
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Any, Dict
 
 
-# NOTE: common to all SQL configs
-class PostgresParseConfig(AttrDict):
+class PostgresConnectionConfig(AttrDict):
     """Configuration data model for
-    [`PostgresParseStrategy`][oteapi.strategies.parse.application_vnd_postgres.PostgresParseStrategy]."""
+    [`PostgresResourceStrategy`][oteapi.strategies.resource.application_vnd_postgres.PostgresParseStrategy]."""
 
+    # TODO this is *NOT* where the sqlquery should be placed! 
     sqlquery: str = Field("", description="A SQL query string.")
+    # TODO not the final way to pass connection info (should be a dictionary-like object)
+    connection_str: str = Field("", description="String used for connection with postgres DB via psycopg.")
     datacache_config: Optional[DataCacheConfig] = Field(
         None,
         description="Configuration options for the local data cache.",
     )
 
 
-class PostgresParserResourceConfig(ResourceConfig):
-    """Postgres parse strategy resource config."""
+# 
+class PostgresResourceConfig(ResourceConfig):
+    """Postgres resource strategy resource config."""
 
-    mediaType: str = Field(
-        "application/vnd.postgres",
-        const=True,
-        description=ResourceConfig.__fields__["mediaType"].field_info.description,
+    accessUrl: HostlessAnyUrl = Field(
+        ...,
+        description=ResourceConfig.__fields__["accessUrl"].field_info.description,
     )
-    configuration: PostgresParseConfig = Field(
-        PostgresParseConfig(), description="Postgres parse strategy-specific configuration."
+    accessService: Optional[str] = Field(
+        str, description="services to use for access?"
+    )
+    configuration: PostgresConnectionConfig = Field(
+        PostgresConnectionConfig(), description="Postgres resource strategy-specific configuration."
     )
 
 
-def create_connection(conn_config: dict) -> psycopg.Connection:
+# TODO: using a string for conn_config to demo, but should go back to dictionary later
+def create_connection(conn_config: str) -> psycopg.Connection:
     """Create a database connection to Postgres database.
 
     Parameters:
@@ -54,20 +61,20 @@ def create_connection(conn_config: dict) -> psycopg.Connection:
 
     """
     try:
-        return psycopg.connect(**conn_config)
+        return psycopg.connect(conn_config)
     except psycopg.Error as exc:
         raise psycopg.Error("Could not connect to given Postgres DB.") from exc
 
 
-class SessionUpdatePostgresParse(SessionUpdate):
-    """Configuration model for PostgresParse."""
+class SessionUpdatePostgresResource(SessionUpdate):
+    """Configuration model for PostgresResource."""
 
     result: list = Field(..., description="List of results from the query.")
 
 
 @dataclass
-class PostgresParseStrategy:
-    """Parse strategy for Postgres.
+class PostgresResourceStrategy:
+    """Resource strategy for Postgres.
 
     **Registers strategies**:
 
@@ -78,7 +85,7 @@ class PostgresParseStrategy:
 
     """
 
-    parse_config: PostgresParserResourceConfig
+    resource_config: PostgresResourceConfig 
 
     def initialize(self, session: "Optional[Dict[str, Any]]" = None) -> SessionUpdate:
         """Initialize strategy."""
@@ -86,23 +93,23 @@ class PostgresParseStrategy:
 
     def get(
         self, session: "Optional[Dict[str, Any]]" = None
-    ) -> SessionUpdatePostgresParse:
-        """Parse Postgres query responses."""
+    ) -> SessionUpdatePostgresResource:
+        """Resource Postgres query responses."""
         if session:
             self._use_filters(session)
         session = session if session else {}
 
         # Not yet sure how to set up the connection config...
-        conn_config = self.parse_config.copy()['conn_config']
+        conn_config = self.resource_config.configuration.connection_str
 
         connection = create_connection(conn_config)
         cursor = connection.cursor()
-        result = cursor.execute(self.parse_config.configuration.sqlquery).fetchall()
+        result = cursor.execute(self.resource_config.configuration.sqlquery).fetchall()
         connection.close()
-        return SessionUpdatePostgresParse(result=result)
+        return SessionUpdatePostgresResource(result=result)
 
     def _use_filters(self, session: "Dict[str, Any]") -> None:
         """Update `config` according to filter values found in the session."""
-        if "sqlquery" in session and not self.parse_config.configuration.sqlquery:
+        if "sqlquery" in session and not self.resource_config.configuration.sqlquery:
             # Use SQL query available in session
-            self.parse_config.configuration.sqlquery = session["sqlquery"]
+            self.resource_config.configuration.sqlquery = session["sqlquery"]

--- a/scratch_launch-docker.sh
+++ b/scratch_launch-docker.sh
@@ -1,0 +1,1 @@
+docker run --name postgres -e POSTGRES_PASSWORD=postgres -d -p 5432:5432  --mount type=bind,source=$(realpath tests),target=/app postgres

--- a/scratch_test-manually.ipynb
+++ b/scratch_test-manually.ipynb
@@ -1,0 +1,253 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "7a1e5b00-9de5-409f-b976-bbf08dab0b2d",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "1e6563d56e3d91f8f13780f29b7b7b4f9c26e29840a76cb57efcc07af1ac9f6b\n"
+     ]
+    }
+   ],
+   "source": [
+    "# initialize docker\n",
+    "! sh ./scratch_launch-docker.sh"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "1c2bf728-1363-4550-bc69-77bff94aa0d7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Run this cell *only-once* to manually generate the docker database. \n",
+    "\n",
+    "import psycopg\n",
+    "import os\n",
+    "import sqlite3 \n",
+    "import pandas as pd\n",
+    "\n",
+    "sample_file = \"./tests/static/sample1.db\"\n",
+    "# reading data out of sqlite db\n",
+    "con = sqlite3.connect(sample_file)\n",
+    "cur = con.cursor()\n",
+    "data = []\n",
+    "for row in cur.execute('SELECT * FROM user_details;'):\n",
+    "    data.append(row)\n",
+    "\n",
+    "columns = ['user_id','username','first_name','last_name','gender','password','status']\n",
+    "types = ['int(11)','varchar(255)','varchar(50)','varchar(50)','varchar(10)','varchar(50)','tinyint(10)']\n",
+    "df = pd.DataFrame(data=data, columns=columns)\n",
+    "\n",
+    "with psycopg.connect(\"dbname=postgres user=postgres password=postgres port=5432 host=localhost\") as conn:\n",
+    "    with conn.cursor() as cur:\n",
+    "        tmp_df = \"./tests/static/tmp_dataframe.csv\"\n",
+    "        df.to_csv(tmp_df, index_label='id', header=False, index=False)\n",
+    "        cur.execute(\"CREATE TABLE user_details ( user_id INT, username VARCHAR(255), first_name VARCHAR(50), last_name VARCHAR(50), gender VARCHAR(10), password VARCHAR(50), status INT, PRIMARY KEY (user_id))\")\n",
+    "        cur.execute(\"COPY user_details FROM '/app/static/tmp_dataframe.csv' csv header;\")\n",
+    "        os.remove(tmp_df)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "ec17e40d-d845-4712-9fb4-a2b46bf6f2e1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sqlite_queries = [\n",
+    "    (\n",
+    "        \"SELECT * FROM user_details WHERE user_details.user_id = 19;\",\n",
+    "        (\n",
+    "            19,\n",
+    "            \"jenny0988\",\n",
+    "            \"maria\",\n",
+    "            \"morgan\",\n",
+    "            \"Female\",\n",
+    "            \"ec9ed18ae2a13fef709964af24bb60e6\",\n",
+    "            1,\n",
+    "        ),\n",
+    "    ),\n",
+    "    (\n",
+    "        \"SELECT * FROM user_details WHERE user_details.user_id = 72;\",\n",
+    "        (\n",
+    "            72,\n",
+    "            \"brown84\",\n",
+    "            \"john\",\n",
+    "            \"ross\",\n",
+    "            \"Male\",\n",
+    "            \"738cb4da81a2790a9a845f902a811ea2\",\n",
+    "            1,\n",
+    "        ),\n",
+    "    ),\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "76beec3f-48a8-4799-be44-db8ff251dcea",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "SessionUpdateSqLiteParse(result=[(19, 'jenny0988', 'maria', 'morgan', 'Female', 'ec9ed18ae2a13fef709964af24bb60e6', 1)])"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#Testing sqlite version\n",
+    "\n",
+    "from oteapi.strategies.parse.application_vnd_sqlite import SqliteParseStrategy\n",
+    "from pathlib import Path\n",
+    "\n",
+    "sample_file = Path(\"/home/daniel/RnD/EMMC/postgres_strategy/oteapi-core/tests/static/sample1.db\")\n",
+    "\n",
+    "from oteapi.plugins import load_strategies\n",
+    "\n",
+    "load_strategies(test_for_uniqueness=False)\n",
+    "\n",
+    "query = sqlite_queries[0][0]\n",
+    "\n",
+    "config = {\n",
+    "    \"downloadUrl\": sample_file.as_uri(),\n",
+    "    \"mediaType\": \"application/vnd.sqlite3\",#\"application/vnd.postgres\",\n",
+    "    \"configuration\": {\"sqlquery\": query},\n",
+    "}\n",
+    "\n",
+    "parser: \"IParseStrategy\" = SqliteParseStrategy(config)\n",
+    "parser.initialize()\n",
+    "\n",
+    "# result = parser.get({\"sqlquery\": query})\n",
+    "# parser.get({\"sqlquery\": None})\n",
+    "parser.get()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "54676bae-0e24-4126-98c0-16fda748942e",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "SessionUpdatePostgresResource(result=[(19, 'jenny0988', 'maria', 'morgan', 'Female', 'ec9ed18ae2a13fef709964af24bb60e6', 1)])"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Testing postgres version \n",
+    "\n",
+    "from oteapi.strategies.resource.application_vnd_postgres import PostgresResourceStrategy\n",
+    "\n",
+    "\n",
+    "from oteapi.plugins import load_strategies\n",
+    "\n",
+    "load_strategies(test_for_uniqueness=False)\n",
+    "\n",
+    "query = sqlite_queries[0][0]\n",
+    "\n",
+    "connection_dict = {\n",
+    "    \"dbname\":\"postgres\",\n",
+    "    \"user\":\"postgres\",\n",
+    "    \"password\":\"postgres\",\n",
+    "    \"host\":\"localhost\"\n",
+    "}\n",
+    "config = {\n",
+    "    \"accessUrl\": \"postgresql://\",\n",
+    "    \"accessService\": \"foo\",\n",
+    "    \"configuration\": {\"sqlquery\": query,\n",
+    "                      # \"connection_str\": connection_str},\n",
+    "                      \"connection_dict\": connection_dict},\n",
+    "\n",
+    "}\n",
+    "\n",
+    "parser: \"IResourceStrategy\" = PostgresResourceStrategy(config)\n",
+    "parser.initialize()\n",
+    "\n",
+    "parser.get({\"sqlquery\": None})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 95,
+   "id": "0a2e15bb-ef97-47c4-9440-628d792f4917",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ParseResult(scheme='postgres', netloc='postgres:postgres@localhost:5432', path='/postgres', params='', query='', fragment='')"
+      ]
+     },
+     "execution_count": 95,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# scratch ideas for using only a url address \n",
+    "import urllib.parse\n",
+    "\n",
+    "urllib.parse.urlparse(\"postgres://postgres:postgres@localhost:5432/postgres\")\n",
+    "# strategy can connect if scheme = postgres \n",
+    "postgresql://[user[:password]@][netloc][:port][/dbname][?param1=value1&...]\n",
+    "with psycopg.connect(\"dbname=postgres user=postgres password=postgres port=5432 host=localhost\") as conn:\n",
+    "    \n",
+    "pg_uri = \"postgres://jeff:hunter2@example.com/db\"\n",
+    "conn_dict =  psycopg.conninfo.conninfo_to_dict(pg_uri)\n",
+    "urllib.parse.urlparse(\"postgres://postgres:postgres@localhost:5432/postgres\")\n",
+    "\n",
+    "with psycopg.connect(\"postgresql://postgres:postgres@localhost:5432/postgres][?param1=value1&...]\") as conn:\n",
+    "    with conn.cursor() as cur:\n",
+    "        tmp_df = \"./tests/static/tmp_dataframe.csv\"\n",
+    "        df.to_csv(tmp_df, index_label='id', header=False, index=False)\n",
+    "        cur.execute(\"CREATE TABLE user_details ( user_id INT, username VARCHAR(255), first_name VARCHAR(50), last_name VARCHAR(50), gender VARCHAR(10), password VARCHAR(50), status INT, PRIMARY KEY (user_id))\")\n",
+    "        cur.execute(\"COPY user_details FROM '/app/static/tmp_dataframe.csv' csv header;\")\n",
+    "        os.remove(tmp_df)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.14"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "f9f85f796d01129d0dd105a088854619f454435301f6ffec2fea96ecbd9be4ac"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,9 @@ oteapi.mapping =
 oteapi.filter =
   oteapi.filter/crop = oteapi.strategies.filter.crop_filter:CropImageFilter
   oteapi.filter/sql = oteapi.strategies.filter.sql_query_filter:SQLQueryFilter
+oteapi.resource =
+ oteapi.resource/vnd.postgres = oteapi.strategies.resource.application_vnd_postgres:PostgresResourceConfig
+
 oteapi.parse =
   oteapi.application/vnd.openxmlformats-officedocument.spreadsheetml.sheet = oteapi.strategies.parse.excel_xlsx:XLSXParseStrategy
   oteapi.image/jpg = oteapi.strategies.parse.image:ImageDataParseStrategy


### PR DESCRIPTION
# Description:
Adds a postgres strategy to oteapi. This works but still is too 'pragmatic' and requires some work to make it more in the spirit of oteapi. There are two 'scratch' files that need to be removed before the final merge but are very useful for testing:

1. scratch_launch-docker.sh sets up the postgres docker instance 
2. scratch_test-manually.ipynb sets up a database in our postgres instance and then runs a test manually. 

There are areas I would like some input that are marked explicitly with TODO statements. We should also think a bit about how we can test this after it is pulled, by either (A) building the postgress DB every time in our CI  or (B) with appropriate mocking. 

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [x] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
