### PR TITLE
Revert removing `--strict` and fix docs build

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -186,4 +186,4 @@ jobs:
       run: |
         invoke create-api-reference-docs --pre-clean
         invoke create-docs-index
-        mkdocs build
+        mkdocs build --strict

--- a/docs/api_reference/models/datacacheconfig.md
+++ b/docs/api_reference/models/datacacheconfig.md
@@ -1,5 +1,5 @@
 # datacacheconfig
 
 ::: oteapi.models.datacacheconfig
-    rendering:
+    options:
       show_if_no_docstring: true

--- a/docs/api_reference/models/filterconfig.md
+++ b/docs/api_reference/models/filterconfig.md
@@ -1,5 +1,5 @@
 # filterconfig
 
 ::: oteapi.models.filterconfig
-    rendering:
+    options:
       show_if_no_docstring: true

--- a/docs/api_reference/models/functionconfig.md
+++ b/docs/api_reference/models/functionconfig.md
@@ -1,5 +1,5 @@
 # functionconfig
 
 ::: oteapi.models.functionconfig
-    rendering:
+    options:
       show_if_no_docstring: true

--- a/docs/api_reference/models/genericconfig.md
+++ b/docs/api_reference/models/genericconfig.md
@@ -1,5 +1,5 @@
 # genericconfig
 
 ::: oteapi.models.genericconfig
-    rendering:
+    options:
       show_if_no_docstring: true

--- a/docs/api_reference/models/mappingconfig.md
+++ b/docs/api_reference/models/mappingconfig.md
@@ -1,5 +1,5 @@
 # mappingconfig
 
 ::: oteapi.models.mappingconfig
-    rendering:
+    options:
       show_if_no_docstring: true

--- a/docs/api_reference/models/resourceconfig.md
+++ b/docs/api_reference/models/resourceconfig.md
@@ -1,5 +1,5 @@
 # resourceconfig
 
 ::: oteapi.models.resourceconfig
-    rendering:
+    options:
       show_if_no_docstring: true

--- a/docs/api_reference/models/sessionupdate.md
+++ b/docs/api_reference/models/sessionupdate.md
@@ -1,5 +1,5 @@
 # sessionupdate
 
 ::: oteapi.models.sessionupdate
-    rendering:
+    options:
       show_if_no_docstring: true

--- a/docs/api_reference/models/transformationconfig.md
+++ b/docs/api_reference/models/transformationconfig.md
@@ -1,5 +1,5 @@
 # transformationconfig
 
 ::: oteapi.models.transformationconfig
-    rendering:
+    options:
       show_if_no_docstring: true

--- a/docs/api_reference/models/triplestoreconfig.md
+++ b/docs/api_reference/models/triplestoreconfig.md
@@ -1,5 +1,5 @@
 # triplestoreconfig
 
 ::: oteapi.models.triplestoreconfig
-    rendering:
+    options:
       show_if_no_docstring: true

--- a/tasks.py
+++ b/tasks.py
@@ -86,7 +86,7 @@ def create_api_reference_docs(context, pre_clean=False, pre_commit=False):
     pages_template = 'title: "{name}"\n'
     md_template = "# {name}\n\n::: {py_path}\n"
     models_template = (
-        md_template + f"{' ' * 4}rendering:\n{' ' * 6}show_if_no_docstring: true\n"
+        md_template + f"{' ' * 4}options:\n{' ' * 6}show_if_no_docstring: true\n"
     )
 
     if docs_api_ref_dir.exists() and pre_clean:


### PR DESCRIPTION
# Description:
<!-- Summary of change, including the issue to be addressed. -->
Fixes #201 
Fixes #203 

Revert 14db66fa33433ea53f062946ad7f703b267d31c1.
Use `options` instead of `rendering` in the API documentation files.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [x] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
