### PR TITLE
Polish `celery/remote` transformation strategy

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -67,6 +67,18 @@ jobs:
         - ["windows-latest", "windows"]
         python-version: ["3.9", "3.10"]
 
+    services:
+      redis:
+        image: redis:latest
+        volumes:
+          - redis-persist:/data
+        ports:
+          - "6379:6379"
+
+    env:
+      OTEAPI_REDIS_HOST: localhost
+      OTEAPI_REDIST_PORT: 6379
+
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -55,16 +55,13 @@ jobs:
         (oteapi/models/transformationconfig.py),[oteapi.models.transformationconfig.TransformationConfig.transformationType]
       warnings_as_errors: true
 
-  pytest:
-    name: pytest (${{ matrix.os[1] }}-py${{ matrix.python-version }})
-    runs-on: ${{ matrix.os[0] }}
+  pytest-linux:
+    name: pytest (linux-py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false
       matrix:
-        os:
-        - ["ubuntu-latest", "linux"]
-        - ["windows-latest", "windows"]
         python-version: ["3.9", "3.10"]
 
     services:
@@ -81,20 +78,61 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-      with:
-        fetch-depth: 2
 
     - name: Set up Python ${{ matrix.python-version}}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version}}
 
-    - name: Install linux system dependencies
-      if: matrix.os[1] == 'linux'
+    - name: Install system dependencies
       run: sudo apt update && sudo apt install -y ghostscript
 
-    - name: Install windows system dependencies
-      if: matrix.os[1] == 'windows'
+    - name: Install Python dependencies
+      run: |
+        python -m pip install -U pip
+        pip install -U setuptools wheel
+        pip install -e .[dev]
+
+    - name: Test with pytest
+      run: pytest -vvv --cov-report=xml
+
+    - name: Upload coverage to Codecov
+      if: matrix.python-version == 3.9 && github.repository == 'EMMC-ASBL/oteapi-core'
+      uses: codecov/codecov-action@v3
+      with:
+        files: coverage.xml
+        flags: linux
+
+    - name: Test with optional libs
+      run: |
+        pip install ase numpy
+        pytest -vvv --cov-report=xml
+
+    - name: Upload coverage to Codecov
+      if: matrix.python-version == 3.9 && github.repository == 'EMMC-ASBL/oteapi-core'
+      uses: codecov/codecov-action@v3
+      with:
+        files: coverage.xml
+        flags: linux-extra_libs
+
+  pytest-win:
+    name: pytest (windows-py${{ matrix.python-version }})
+    runs-on: windows-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9", "3.10"]
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python ${{ matrix.python-version}}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version}}
+
+    - name: Install system dependencies
       run: |
         $url = "https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs9550/gs9550w64.exe"
         $outpath = "${{ github.workspace }}\ghostscript.exe"
@@ -117,7 +155,7 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         files: coverage.xml
-        flags: ${{ matrix.os[1] }}
+        flags: windows
 
     - name: Test with optional libs
       run: |
@@ -129,4 +167,4 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         files: coverage.xml
-        flags: ${{ matrix.os[1] }}-extra_libs
+        flags: windows-extra_libs

--- a/oteapi/strategies/transformation/celery_remote.py
+++ b/oteapi/strategies/transformation/celery_remote.py
@@ -114,12 +114,18 @@ class CeleryRemoteStrategy:
             session: The current OTE session.
 
         """
+        alias_mapping: dict[str, str] = {
+            field.alias: field_name
+            for field_name, field in CeleryConfig.__fields__.items()
+        }
+
         fields = set(CeleryConfig.__fields__)
         fields |= {_.alias for _ in CeleryConfig.__fields__.values()}
+
         for field in fields:
             if field in session:
                 setattr(
                     self.transformation_config.configuration,
-                    field,
+                    alias_mapping[field],
                     session[field],
                 )

--- a/oteapi/strategies/transformation/celery_remote.py
+++ b/oteapi/strategies/transformation/celery_remote.py
@@ -28,15 +28,24 @@ CELERY_APP = Celery(
 )
 
 
-class CeleryConfig(AttrDict):
+class CeleryConfig(AttrDict, allow_population_by_field_name=True):
     """Celery configuration.
 
     All fields here (including those added from the session through the `get()` method,
     as well as those added "anonymously") will be used as keyword arguments to the
     `send_task()` method for the Celery App.
+
+    Note:
+        Using `alias` for the `name` field to favor populating it with `task_name`
+        arguments, since this is the "original" field name. I.e., this is done for
+        backwards compatibility.
+
+    Setting `allow_population_by_field_name=True` as pydantic model configuration in
+    order to allow populating it using `name` as well as `task_name`.
+
     """
 
-    name: str = Field(..., description="A task name.")
+    name: str = Field(..., description="A task name.", alias="task_name")
     args: list = Field(..., description="List of arguments for the task.")
 
 

--- a/oteapi/strategies/transformation/celery_remote.py
+++ b/oteapi/strategies/transformation/celery_remote.py
@@ -103,8 +103,20 @@ class CeleryRemoteStrategy:
         return TransformationStatus(id=task_id, status=result.state)
 
     def _use_session(self, session: "Dict[str, Any]") -> None:
-        """Update the configuration with values from the sesssion."""
-        for field in CeleryConfig.__fields__:
+        """Update the configuration with values from the sesssion.
+
+        Check all fields (non-aliased and aliased) in `CeleryConfig` if they exist in
+        the session. Override the given field values in the current strategy-specific
+        configuration (the `CeleryConfig` instance) with the values found in the
+        session.
+
+        Parameters:
+            session: The current OTE session.
+
+        """
+        fields = set(CeleryConfig.__fields__)
+        fields |= {_.alias for _ in CeleryConfig.__fields__.values()}
+        for field in fields:
             if field in session:
                 setattr(
                     self.transformation_config.configuration,

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,6 +2,6 @@ pre-commit>=2.21.0,<3; python_version<"3.8"
 pre-commit~=3.1; python_version>="3.8"
 pylint~=2.16
 pytest~=7.2
-pytest-celery~=0
+pytest-celery
 pytest-cov~=4.0
 requests-mock~=1.10

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,5 +2,6 @@ pre-commit>=2.21.0,<3; python_version<"3.8"
 pre-commit~=3.1; python_version>="3.8"
 pylint~=2.16
 pytest~=7.2
+pytest-celery~=0
 pytest-cov~=4.0
 requests-mock~=1.10

--- a/tests/strategies/transformation/test_celery_remote.py
+++ b/tests/strategies/transformation/test_celery_remote.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 def celery_config() -> dict[str, str]:
     """Set Celery fixture configuration."""
     import os
+    import platform
 
     import redis
 
@@ -22,7 +23,9 @@ def celery_config() -> dict[str, str]:
     try:
         client.ping()
     except redis.ConnectionError:
-        if os.getenv("CI"):  # And OS is Linux!
+        if os.getenv("CI") and platform.system() == "Linux":
+            # Starting services (like redis) is only supported in GH Actions for the
+            # Linux OS
             pytest.fail("In CI environment - this test MUST run !")
         else:
             pytest.skip(f"No redis connection at {host}:{port} for testing celery.")

--- a/tests/strategies/transformation/test_celery_remote.py
+++ b/tests/strategies/transformation/test_celery_remote.py
@@ -1,0 +1,80 @@
+"""Tests the transformation strategy for Celery."""
+# pylint: disable=invalid-name
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from celery import Celery
+    from celery.contrib.testing.worker import TestWorkController
+
+
+@pytest.fixture(scope="session")
+def celery_config() -> dict[str, str]:
+    """Set Celery fixture configuration."""
+    import os
+
+    import redis
+
+    host = os.getenv("OTEAPI_REDIS_HOST", "localhost")
+    port = int(os.getenv("OTEAPI_REDIS_PORT", "6379"))
+    client = redis.Redis(host=host, port=port)
+    try:
+        client.ping()
+    except redis.ConnectionError:
+        pytest.skip(f"No redis connection at {host}:{port} for testing celery.")
+
+    return {
+        "broker_url": f"redis://{host}:{port}",
+        "result_backend": f"redis://{host}:{port}",
+    }
+
+
+def test_celery_remote(
+    celery_app: "Celery",
+    celery_worker: "TestWorkController",
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Test `celery/remote` transformation strategy."""
+    from time import sleep, time
+
+    from celery.result import AsyncResult
+
+    from oteapi.models.transformationconfig import TransformationConfig
+    from oteapi.strategies.transformation import celery_remote
+
+    @celery_app.task
+    def add(x: float, y: float) -> float:
+        """Simple addition task to test Celery."""
+        return x + y
+
+    celery_worker.reload()
+
+    monkeypatch.setattr(celery_remote, "CELERY_APP", celery_app)
+
+    config = TransformationConfig(
+        transformationType="celery/remote",
+        configuration={
+            "name": add.name,
+            "args": [1, 2],
+        },
+    )
+    transformation = celery_remote.CeleryRemoteStrategy(config)
+
+    session = transformation.initialize({})
+    session = transformation.get(session)
+
+    assert session.get("celery_task_id", "")
+
+    start_time = time()
+    while (
+        transformation.status(session.celery_task_id).status != "SUCCESS"
+        and time() < start_time + 5
+    ):
+        sleep(1)
+
+    if transformation.status(session.celery_task_id).status != "SUCCESS":
+        pytest.fail("Status never changed to 'SUCCESS' !")
+
+    result = AsyncResult(id=session.celery_task_id, app=celery_app)
+    assert result.result == add(1, 2)

--- a/tests/strategies/transformation/test_celery_remote.py
+++ b/tests/strategies/transformation/test_celery_remote.py
@@ -22,7 +22,10 @@ def celery_config() -> dict[str, str]:
     try:
         client.ping()
     except redis.ConnectionError:
-        pytest.skip(f"No redis connection at {host}:{port} for testing celery.")
+        if os.getenv("CI"):  # And OS is Linux!
+            pytest.fail("In CI environment - this test MUST run !")
+        else:
+            pytest.skip(f"No redis connection at {host}:{port} for testing celery.")
 
     return {
         "broker_url": f"redis://{host}:{port}",

--- a/tests/strategies/transformation/test_celery_remote.py
+++ b/tests/strategies/transformation/test_celery_remote.py
@@ -63,7 +63,7 @@ def test_celery_remote(
     config = TransformationConfig(
         transformationType="celery/remote",
         configuration={
-            "name": add.name,
+            "task_name": add.name,
             "args": [1, 2],
         },
     )
@@ -86,3 +86,17 @@ def test_celery_remote(
 
     result = AsyncResult(id=session.celery_task_id, app=celery_app)
     assert result.result == add(1, 2)
+
+
+def test_celery_config_name() -> None:
+    """Check `CeleryConfig` can be populated with/-out alias use."""
+    from oteapi.strategies.transformation.celery_remote import CeleryConfig
+
+    aliased_keys = ("task_name", "args")
+    non_aliased_keys = ("name", "args")
+
+    values = ("app.add", [1, 2])
+
+    assert CeleryConfig(**dict(zip(aliased_keys, values))) == CeleryConfig(
+        **dict(zip(non_aliased_keys, values))
+    )

--- a/tests/strategies/transformation/test_celery_remote.py
+++ b/tests/strategies/transformation/test_celery_remote.py
@@ -50,6 +50,8 @@ def test_celery_remote(
 
     celery_worker.reload()
 
+    # Use the test celery app instead of the strategy's celery app
+    # The strategy's celery app has not registered the `add()` task...
     monkeypatch.setattr(celery_remote, "CELERY_APP", celery_app)
 
     config = TransformationConfig(


### PR DESCRIPTION
# Description:
<!-- Summary of change, including the issue to be addressed. -->
Closes #236 

Starting with a test for running the strategy, the related strategy models have been refined. An issue for using the pytest fixtures were found - the Celery documentation has been fixed in celery/celery#7857, but this has yet to be published, which resulted in lots of wasted time :(

Currently, the test is not appropriately testing the strategy, but rather injecting it's own "test" Celery App instead of the strategy's Celery App.
The test should be updated or another should be added to check the actual implementation of the strategy works as intended.

Through this work it has become apparent that an important step is missing: Creating a Celery Task that can actually be referenced in the `get()` method.
I think it makes most sense to register/create tasks in the `initialize()` step of the strategy. Another alternative is to have pre-defined tasks that can be referenced, however, this is slightly opaque for the user.

Note: One must run a local redis instance to test the celery/remote strategy.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
