### PR TITLE
Pin urllib3 to v1.x

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ Pillow>=9.0.0,<10
 pydantic>=1.9.0,<2
 pysftp~=0.2.9
 requests>=2.26.0,<3
+urllib3<2


### PR DESCRIPTION
# Description:
<!-- Summary of change, including the issue to be addressed. -->
This is due to urllib3 v2 being used in requests v2.30, but allegrograph not supporting it.

The issue does not present itself in any tests here, but it _does_ present itself in tests for Services (see [this CI run](https://github.com/EMMC-ASBL/oteapi-services/actions/runs/4946619337/jobs/8844942320)).
The issue lies in allegrograph not supporting urllib3 v2.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
