### PR TITLE
Update to SINTEF/ci-cd v2

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -8,17 +8,17 @@ on:
 jobs:
   publish:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/cd_release.yml@v1
+    uses: SINTEF/ci-cd/.github/workflows/cd_release.yml@v2.3.1
     if: github.repository == 'EMMC-ASBL/oteapi-core' && startsWith(github.ref, 'refs/tags/v')
     with:
       # General
       git_username: "TEAM 4.0[bot]"
       git_email: "Team4.0@SINTEF.no"
+      release_branch: master
 
       # Publish to PyPI
       python_package: true
       package_dirs: oteapi
-      release_branch: master
       python_version_build: "3.9"
       install_extras: "[dev]"
       build_cmd: "python -m build"

--- a/.github/workflows/ci_automerge_dependabot.yml
+++ b/.github/workflows/ci_automerge_dependabot.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   update-dependabot-branch:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/ci_automerge_prs.yml@v1
+    uses: SINTEF/ci-cd/.github/workflows/ci_automerge_prs.yml@v2.3.1
     if: github.repository_owner == 'EMMC-ASBL' && startsWith(github.event.pull_request.head.ref, 'dependabot/') && github.actor == 'dependabot[bot]'
     secrets:
       PAT: ${{ secrets.RELEASE_PAT }}

--- a/.github/workflows/ci_cd_updated_master.yml
+++ b/.github/workflows/ci_cd_updated_master.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   updates-to-master:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/ci_cd_updated_default_branch.yml@v1
+    uses: SINTEF/ci-cd/.github/workflows/ci_cd_updated_default_branch.yml@v2.3.1
     if: github.repository_owner == 'EMMC-ASBL'
     with:
       # General

--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   create-collected-pr:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/ci_update_dependencies.yml@v1
+    uses: SINTEF/ci-cd/.github/workflows/ci_update_dependencies.yml@v2.3.1
     if: github.repository_owner == 'EMMC-ASBL'
     with:
       # General

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   basic_tests:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/ci_tests.yml@v1
+    uses: SINTEF/ci-cd/.github/workflows/ci_tests.yml@v2.3.1
     with:
       # pre-commit
       run_pre-commit: true
@@ -28,9 +28,6 @@ jobs:
         --rcfile=pyproject.toml --extension-pkg-whitelist='pydantic' --disable=C0415,W0621,import-error --recursive=yes tests
 
       run_safety: true
-      # Ignore ID 44715 for now.
-      # See this NumPy issue for more information: https://github.com/numpy/numpy/issues/19038
-      safety_options: --ignore=44715
 
       # Build package
       run_build_package: true
@@ -97,7 +94,7 @@ jobs:
       run: pytest -vvv --cov-report=xml
 
     - name: Upload coverage to Codecov
-      if: matrix.python-version == 3.9 && github.repository == 'EMMC-ASBL/oteapi-core'
+      if: matrix.python-version == '3.9' && github.repository == 'EMMC-ASBL/oteapi-core'
       uses: codecov/codecov-action@v3
       with:
         files: coverage.xml
@@ -109,7 +106,7 @@ jobs:
         pytest -vvv --cov-report=xml
 
     - name: Upload coverage to Codecov
-      if: matrix.python-version == 3.9 && github.repository == 'EMMC-ASBL/oteapi-core'
+      if: matrix.python-version == '3.9' && github.repository == 'EMMC-ASBL/oteapi-core'
       uses: codecov/codecov-action@v3
       with:
         files: coverage.xml
@@ -151,7 +148,7 @@ jobs:
       run: pytest -vvv --cov-report=xml
 
     - name: Upload coverage to Codecov
-      if: matrix.python-version == 3.9 && github.repository == 'EMMC-ASBL/oteapi-core'
+      if: matrix.python-version == '3.9' && github.repository == 'EMMC-ASBL/oteapi-core'
       uses: codecov/codecov-action@v3
       with:
         files: coverage.xml
@@ -163,7 +160,7 @@ jobs:
         pytest -vvv --cov-report=xml
 
     - name: Upload coverage to Codecov
-      if: matrix.python-version == 3.9 && github.repository == 'EMMC-ASBL/oteapi-core'
+      if: matrix.python-version == '3.9' && github.repository == 'EMMC-ASBL/oteapi-core'
       uses: codecov/codecov-action@v3
       with:
         files: coverage.xml


### PR DESCRIPTION
# Description:
<!-- Summary of change, including the issue to be addressed. -->
Use that latest version of SINTE/ci-cd in callable workflows for CI/CD.
There was [an issue](https://github.com/EMMC-ASBL/oteapi-core/actions/runs/4958894157/jobs/8872460179) when trying to release v0.4.2. Switching to the latest version of the callable workflows should ensure that this is fixed, as well as help dependabot update the version going forward.

Furthermore, this PR removes the safety ignore for NumPy.

Closes #265 

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
