### PR TITLE
Use typing-extensions for Python <= 3.9

### DIFF
--- a/oteapi/strategies/parse/image.py
+++ b/oteapi/strategies/parse/image.py
@@ -1,7 +1,13 @@
 """Strategy class for image/jpg."""
 # pylint: disable=unused-argument
+import sys
 from enum import Enum
-from typing import TYPE_CHECKING, Literal, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Optional, Tuple
+
+if sys.version_info >= (3, 10):
+    from typing import Literal
+else:
+    from typing_extensions import Literal
 
 import numpy as np
 from PIL import Image
@@ -49,14 +55,14 @@ class ImageParserConfig(AttrDict):
 class ImageParserResourceConfig(ResourceConfig):
     """Image parse strategy resource config."""
 
-    mediaType: Union[
-        Literal["image/jpg"],
-        Literal["image/jpeg"],
-        Literal["image/jp2"],
-        Literal["image/png"],
-        Literal["image/gif"],
-        Literal["image/tiff"],
-        Literal["image/eps"],
+    mediaType: Literal[
+        "image/jpg",
+        "image/jpeg",
+        "image/jp2",
+        "image/png",
+        "image/gif",
+        "image/tiff",
+        "image/eps",
     ] = Field(
         ...,
         description=ResourceConfig.__fields__["mediaType"].field_info.description,

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,5 @@ Pillow>=9.0.0,<10
 pydantic>=1.9.0,<2
 pysftp~=0.2.9
 requests>=2.26.0,<3
+typing-extensions~=4.6
 urllib3<2


### PR DESCRIPTION
# Description:
<!-- Summary of change, including the issue to be addressed. -->
Use (and depend on) typing-extensions for the Literal type if using Python <= 3.9.
Normally, this should only be an issue for Python < 3.8, however, it seems to have become an issue for Python 3.8 and 3.9 as well.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
