### PR TITLE
Fully document strategies

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,6 +54,12 @@ repos:
       args:
       - --package-dir=oteapi
       - --full-docs-folder=models
+      - --full-docs-folder=strategies/download
+      - --full-docs-folder=strategies/filter
+      - --full-docs-folder=strategies/mapping
+      - --full-docs-folder=strategies/parse
+      - --full-docs-folder=strategies/resource
+      - --full-docs-folder=strategies/transformation
     - id: docs-landing-page
       args:
       - --replacement=(LICENSE),(LICENSE.md)

--- a/docs/all_models.md
+++ b/docs/all_models.md
@@ -5,3 +5,6 @@ This page provides documentation for the `oteapi.models` submodule, where all th
 When creating instances of these models, the data types are automatically validated.
 
 ::: oteapi.models
+    options:
+      show_submodules: true
+      show_if_no_docstring: true

--- a/docs/all_strategies.md
+++ b/docs/all_strategies.md
@@ -5,3 +5,6 @@ This page provides documentation for the `oteapi.strategies` submodule, where al
 These strategies will always be available when setting up a server based on the OTE-API Core package.
 
 ::: oteapi.strategies
+    options:
+      show_submodules: true
+      show_if_no_docstring: true

--- a/docs/api_reference/strategies/download/file.md
+++ b/docs/api_reference/strategies/download/file.md
@@ -1,3 +1,5 @@
 # file
 
 ::: oteapi.strategies.download.file
+    options:
+      show_if_no_docstring: true

--- a/docs/api_reference/strategies/download/https.md
+++ b/docs/api_reference/strategies/download/https.md
@@ -1,3 +1,5 @@
 # https
 
 ::: oteapi.strategies.download.https
+    options:
+      show_if_no_docstring: true

--- a/docs/api_reference/strategies/download/sftp.md
+++ b/docs/api_reference/strategies/download/sftp.md
@@ -1,3 +1,5 @@
 # sftp
 
 ::: oteapi.strategies.download.sftp
+    options:
+      show_if_no_docstring: true

--- a/docs/api_reference/strategies/filter/crop_filter.md
+++ b/docs/api_reference/strategies/filter/crop_filter.md
@@ -1,3 +1,5 @@
 # crop_filter
 
 ::: oteapi.strategies.filter.crop_filter
+    options:
+      show_if_no_docstring: true

--- a/docs/api_reference/strategies/filter/sql_query_filter.md
+++ b/docs/api_reference/strategies/filter/sql_query_filter.md
@@ -1,3 +1,5 @@
 # sql_query_filter
 
 ::: oteapi.strategies.filter.sql_query_filter
+    options:
+      show_if_no_docstring: true

--- a/docs/api_reference/strategies/mapping/mapping.md
+++ b/docs/api_reference/strategies/mapping/mapping.md
@@ -1,3 +1,5 @@
 # mapping
 
 ::: oteapi.strategies.mapping.mapping
+    options:
+      show_if_no_docstring: true

--- a/docs/api_reference/strategies/parse/application_json.md
+++ b/docs/api_reference/strategies/parse/application_json.md
@@ -1,3 +1,5 @@
 # application_json
 
 ::: oteapi.strategies.parse.application_json
+    options:
+      show_if_no_docstring: true

--- a/docs/api_reference/strategies/parse/application_vnd_sqlite.md
+++ b/docs/api_reference/strategies/parse/application_vnd_sqlite.md
@@ -1,3 +1,5 @@
 # application_vnd_sqlite
 
 ::: oteapi.strategies.parse.application_vnd_sqlite
+    options:
+      show_if_no_docstring: true

--- a/docs/api_reference/strategies/parse/excel_xlsx.md
+++ b/docs/api_reference/strategies/parse/excel_xlsx.md
@@ -1,3 +1,5 @@
 # excel_xlsx
 
 ::: oteapi.strategies.parse.excel_xlsx
+    options:
+      show_if_no_docstring: true

--- a/docs/api_reference/strategies/parse/image.md
+++ b/docs/api_reference/strategies/parse/image.md
@@ -1,3 +1,5 @@
 # image
 
 ::: oteapi.strategies.parse.image
+    options:
+      show_if_no_docstring: true

--- a/docs/api_reference/strategies/parse/text_csv.md
+++ b/docs/api_reference/strategies/parse/text_csv.md
@@ -1,3 +1,5 @@
 # text_csv
 
 ::: oteapi.strategies.parse.text_csv
+    options:
+      show_if_no_docstring: true

--- a/docs/api_reference/strategies/resource/postgres.md
+++ b/docs/api_reference/strategies/resource/postgres.md
@@ -1,3 +1,5 @@
 # postgres
 
 ::: oteapi.strategies.resource.postgres
+    options:
+      show_if_no_docstring: true

--- a/docs/api_reference/strategies/transformation/celery_remote.md
+++ b/docs/api_reference/strategies/transformation/celery_remote.md
@@ -1,3 +1,5 @@
 # celery_remote
 
 ::: oteapi.strategies.transformation.celery_remote
+    options:
+      show_if_no_docstring: true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,16 +56,21 @@ plugins:
       handlers:
         python:
           options:
+            # General options
+            show_bases: true
+            show_source: true
+
+            # Headings options
+            heading_level: 2
             show_root_heading: false
             show_root_toc_entry: true
             show_root_full_path: true
             show_object_full_path: false
             show_category_heading: false
-            show_if_no_docstring: false
-            show_source: true
-            show_bases: true
-            group_by_category: true
-            heading_level: 2
+
+            # Members options
+            inherited_members: false
+            members: null
             filters:
               - "!^_"
               - "^__init__$"
@@ -74,13 +79,16 @@ plugins:
               - "!__config__$"
               - "!__str__$"
               - "!__repr__$"
-            members: null
-            # inherited_members: false
+            group_by_category: true
+
+            # Docstrings options
             docstring_style: google
-          #   docstring_options:
-          #     replace_admonitions: true
-      watch:
-        - oteapi
+            docstring_options:
+              replace_admonitions: true
+            show_if_no_docstring: false
+
+            # Signatures/annotations options
+            line_length: 88
   - awesome-pages
 
 nav:
@@ -90,3 +98,6 @@ nav:
   - all_models.md
   - all_strategies.md
   - ... | api_reference/**
+
+watch:
+  - oteapi


### PR DESCRIPTION
# Description:
<!-- Summary of change, including the issue to be addressed. -->
Closes #312 

This update utilizes the `show_if_no_docstring` mkdocstrings option ([their documentation](https://mkdocstrings.github.io/python/usage/#options-summary)) to ensure all data model attributes are shown in the documentation. Also for those under `strategies/*`.
Here is an example from the rendered documentation for the Excel parser:
![image](https://github.com/EMMC-ASBL/oteapi-core/assets/43357585/3b575f16-b634-4b07-86c7-04d66b23a218)

Furthermore, I have ensured the top-level documentation pages "All strategies" and "All models" have the same option activated, as well as the `show_submodules` set to `True` to actually render the strategies page, which was up to now empty 😕 

Finally, the MkDocs configuration file has been slightly updated and hopefully made more readable for the mkdocstrings configuration options.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [ ] New feature.
- [x] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
