### PR TITLE
Added support for relative file paths

### DIFF
--- a/docs/api_reference/strategies/download/file.md
+++ b/docs/api_reference/strategies/download/file.md
@@ -1,3 +1,5 @@
 # file
 
 ::: oteapi.strategies.download.file
+    options:
+      show_if_no_docstring: true

--- a/docs/api_reference/strategies/download/https.md
+++ b/docs/api_reference/strategies/download/https.md
@@ -1,3 +1,5 @@
 # https
 
 ::: oteapi.strategies.download.https
+    options:
+      show_if_no_docstring: true

--- a/docs/api_reference/strategies/download/sftp.md
+++ b/docs/api_reference/strategies/download/sftp.md
@@ -1,3 +1,5 @@
 # sftp
 
 ::: oteapi.strategies.download.sftp
+    options:
+      show_if_no_docstring: true

--- a/docs/api_reference/strategies/filter/crop_filter.md
+++ b/docs/api_reference/strategies/filter/crop_filter.md
@@ -1,3 +1,5 @@
 # crop_filter
 
 ::: oteapi.strategies.filter.crop_filter
+    options:
+      show_if_no_docstring: true

--- a/docs/api_reference/strategies/filter/sql_query_filter.md
+++ b/docs/api_reference/strategies/filter/sql_query_filter.md
@@ -1,3 +1,5 @@
 # sql_query_filter
 
 ::: oteapi.strategies.filter.sql_query_filter
+    options:
+      show_if_no_docstring: true

--- a/docs/api_reference/strategies/mapping/mapping.md
+++ b/docs/api_reference/strategies/mapping/mapping.md
@@ -1,3 +1,5 @@
 # mapping
 
 ::: oteapi.strategies.mapping.mapping
+    options:
+      show_if_no_docstring: true

--- a/docs/api_reference/strategies/parse/application_json.md
+++ b/docs/api_reference/strategies/parse/application_json.md
@@ -1,3 +1,5 @@
 # application_json
 
 ::: oteapi.strategies.parse.application_json
+    options:
+      show_if_no_docstring: true

--- a/docs/api_reference/strategies/parse/application_vnd_sqlite.md
+++ b/docs/api_reference/strategies/parse/application_vnd_sqlite.md
@@ -1,3 +1,5 @@
 # application_vnd_sqlite
 
 ::: oteapi.strategies.parse.application_vnd_sqlite
+    options:
+      show_if_no_docstring: true

--- a/docs/api_reference/strategies/parse/excel_xlsx.md
+++ b/docs/api_reference/strategies/parse/excel_xlsx.md
@@ -1,3 +1,5 @@
 # excel_xlsx
 
 ::: oteapi.strategies.parse.excel_xlsx
+    options:
+      show_if_no_docstring: true

--- a/docs/api_reference/strategies/parse/image.md
+++ b/docs/api_reference/strategies/parse/image.md
@@ -1,3 +1,5 @@
 # image
 
 ::: oteapi.strategies.parse.image
+    options:
+      show_if_no_docstring: true

--- a/docs/api_reference/strategies/parse/text_csv.md
+++ b/docs/api_reference/strategies/parse/text_csv.md
@@ -1,3 +1,5 @@
 # text_csv
 
 ::: oteapi.strategies.parse.text_csv
+    options:
+      show_if_no_docstring: true

--- a/docs/api_reference/strategies/resource/postgres.md
+++ b/docs/api_reference/strategies/resource/postgres.md
@@ -1,3 +1,5 @@
 # postgres
 
 ::: oteapi.strategies.resource.postgres
+    options:
+      show_if_no_docstring: true

--- a/docs/api_reference/strategies/transformation/celery_remote.md
+++ b/docs/api_reference/strategies/transformation/celery_remote.md
@@ -1,3 +1,5 @@
 # celery_remote
 
 ::: oteapi.strategies.transformation.celery_remote
+    options:
+      show_if_no_docstring: true

--- a/oteapi/utils/paths.py
+++ b/oteapi/utils/paths.py
@@ -31,8 +31,10 @@ def uri_to_path(uri: "Union[str, AnyUrl, ParseResult]") -> Path:
         A properly converted URI/IRI/URL to `pathlib.Path`.
 
     """
-    uri = urlparse(uri)  # type: ignore
-    uri_path = uri.netloc + uri.path
+    if not isinstance(uri, ParseResult):
+        uri = urlparse(uri)  # type: ignore
+
+    uri_path = uri.netloc + uri.path if uri.scheme == "file" else uri.path
 
     if uri.scheme != "file":
         warnings.warn(

--- a/oteapi/utils/paths.py
+++ b/oteapi/utils/paths.py
@@ -31,13 +31,8 @@ def uri_to_path(uri: "Union[str, AnyUrl, ParseResult]") -> Path:
         A properly converted URI/IRI/URL to `pathlib.Path`.
 
     """
-    if isinstance(uri, (AnyUrl, ParseResult)):
-        uri_path = uri.path
-    elif isinstance(uri, str):
-        uri = urlparse(uri)
-        uri_path = uri.path
-    else:
-        raise TypeError("uri is expected to be either a string or parsed URI/IRI/URL.")
+    uri = urlparse(uri)  # type: ignore
+    uri_path = uri.netloc + uri.path
 
     if uri.scheme != "file":
         warnings.warn(

--- a/oteapi/utils/paths.py
+++ b/oteapi/utils/paths.py
@@ -34,7 +34,7 @@ def uri_to_path(uri: "Union[str, AnyUrl, ParseResult]") -> Path:
     if not isinstance(uri, ParseResult):
         uri = urlparse(uri)  # type: ignore
 
-    uri_path = uri.netloc + uri.path if uri.scheme == "file" else uri.path
+    uri_path = (uri.netloc + uri.path) if uri.scheme == "file" else uri.path
 
     if uri.scheme != "file":
         warnings.warn(


### PR DESCRIPTION
# Description:
Even though that OTEAPI is designed for working on remote data sources, local files are still a common use case. Currently the file strategy only accepts absolute paths, which is an annoying complication in demonstrations that should work for more than one person. 

The fix is to relay on urllib instead of the buggy FileUrl implementation in pydantic.

This PR only involves a small change in `oteapi/utils/paths.py`. All the other files are dragged in by pre-commit...

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
