### PR TITLE
Support pydantic v1 & v2

### DIFF
--- a/.github/workflows/ci_check_dependencies.yml
+++ b/.github/workflows/ci_check_dependencies.yml
@@ -24,7 +24,7 @@ jobs:
         dependency-name=numpy...version==>=2
         dependency-name=openpyxl...version==>=4
         dependency-name=Pillow...version==>=11
-        dependency-name=pydantic...version==>=2
+        dependency-name=pydantic...version==>=3
         dependency-name=requests...version==>=3
         dependency-name=urllib3
     secrets:

--- a/.gitignore
+++ b/.gitignore
@@ -185,6 +185,9 @@ pythonenv*
 # mkdocs documentation
 /site
 
+# ruff
+.ruff_cache/
+
 # mypy
 .mypy_cache/
 .dmypy.json

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,6 +57,8 @@ repos:
       - --full-docs-folder=strategies/parse
       - --full-docs-folder=strategies/resource
       - --full-docs-folder=strategies/transformation
+      - --unwanted-file=_pydantic.py
+      - --unwanted-file=__init__.py
     - id: docs-landing-page
       args:
       - --replacement=(LICENSE),(LICENSE.md)

--- a/oteapi/models/datacacheconfig.py
+++ b/oteapi/models/datacacheconfig.py
@@ -2,9 +2,8 @@
 from pathlib import Path
 from typing import Optional
 
-from pydantic import Field
-
 from oteapi.models.genericconfig import AttrDict
+from oteapi.utils._pydantic import Field
 
 
 class DataCacheConfig(AttrDict):

--- a/oteapi/models/filterconfig.py
+++ b/oteapi/models/filterconfig.py
@@ -1,9 +1,8 @@
 """Pydantic Filter Configuration Data Model."""
 from typing import Optional
 
-from pydantic import Field
-
 from oteapi.models.genericconfig import GenericConfig
+from oteapi.utils._pydantic import Field
 
 
 class FilterConfig(GenericConfig):

--- a/oteapi/models/functionconfig.py
+++ b/oteapi/models/functionconfig.py
@@ -1,8 +1,7 @@
 """Pydantic Function Configuration Data Model."""
-from pydantic import Field
-
 from oteapi.models.genericconfig import GenericConfig
 from oteapi.models.secretconfig import SecretConfig
+from oteapi.utils._pydantic import Field
 
 
 class FunctionConfig(GenericConfig, SecretConfig):

--- a/oteapi/models/genericconfig.py
+++ b/oteapi/models/genericconfig.py
@@ -1,8 +1,7 @@
 """Generic data model for configuration attributes."""
 from typing import TYPE_CHECKING, Iterable, Mapping
 
-from pydantic import BaseModel, Field
-from pydantic.fields import Undefined
+from oteapi.utils._pydantic import BaseModel, Field, Undefined
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Any, Optional, Tuple, Union

--- a/oteapi/models/mappingconfig.py
+++ b/oteapi/models/mappingconfig.py
@@ -1,9 +1,8 @@
 """Pydantic Mapping Configuration Data Model."""
 from typing import Dict, Optional, Set, Tuple
 
-from pydantic import Field
-
 from oteapi.models.genericconfig import GenericConfig
+from oteapi.utils._pydantic import Field
 
 RDFTriple = Tuple[str, str, str]
 

--- a/oteapi/models/parserconfig.py
+++ b/oteapi/models/parserconfig.py
@@ -1,7 +1,6 @@
 """Pydantic Parser Configuration Data Model."""
-from pydantic import Field
-
 from oteapi.models.genericconfig import GenericConfig
+from oteapi.utils._pydantic import Field
 
 
 class ParserConfig(GenericConfig):

--- a/oteapi/models/resourceconfig.py
+++ b/oteapi/models/resourceconfig.py
@@ -2,10 +2,9 @@
 # pylint: disable=line-too-long
 from typing import TYPE_CHECKING, Optional
 
-from pydantic import AnyUrl, Field, root_validator
-
 from oteapi.models.genericconfig import GenericConfig
 from oteapi.models.secretconfig import SecretConfig
+from oteapi.utils._pydantic import AnyUrl, Field, root_validator
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Any, Dict

--- a/oteapi/models/secretconfig.py
+++ b/oteapi/models/secretconfig.py
@@ -2,9 +2,8 @@
 import json
 from typing import TYPE_CHECKING, Optional
 
-from pydantic import BaseModel, Field, SecretStr
-
 from oteapi.settings import settings
+from oteapi.utils._pydantic import BaseModel, Field, SecretStr
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Any, Callable

--- a/oteapi/models/transformationconfig.py
+++ b/oteapi/models/transformationconfig.py
@@ -8,10 +8,9 @@ from datetime import datetime
 from enum import Enum
 from typing import List, Optional
 
-from pydantic import BaseModel, Field
-
 from oteapi.models.genericconfig import GenericConfig
 from oteapi.models.secretconfig import SecretConfig
+from oteapi.utils._pydantic import BaseModel, Field
 
 
 class ProcessPriority(str, Enum):

--- a/oteapi/models/triplestoreconfig.py
+++ b/oteapi/models/triplestoreconfig.py
@@ -1,10 +1,9 @@
 """Pydantic TripleStore Configuration Data Model."""
 from typing import TYPE_CHECKING
 
-from pydantic import Field, root_validator
-
 from oteapi.models.genericconfig import GenericConfig
 from oteapi.models.secretconfig import SecretConfig
+from oteapi.utils._pydantic import Field, root_validator
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Any, Dict

--- a/oteapi/settings.py
+++ b/oteapi/settings.py
@@ -7,7 +7,7 @@ Otherwise, check `https://github.com/EMMC-ASBL/oteapi-services/blob/master/app/m
 for a direct example of an inclusion of the OTE api and its settings into an FastAPI
 instance.
 """
-from pydantic import BaseSettings, Field
+from oteapi.utils._pydantic import BaseSettings, Field
 
 
 class OteApiCoreSettings(BaseSettings):

--- a/oteapi/strategies/download/file.py
+++ b/oteapi/strategies/download/file.py
@@ -2,11 +2,11 @@
 # pylint: disable=unused-argument
 from typing import TYPE_CHECKING, Optional
 
-from pydantic import Field, FileUrl, validator
-from pydantic.dataclasses import dataclass
-
 from oteapi.datacache import DataCache
 from oteapi.models import AttrDict, DataCacheConfig, ResourceConfig, SessionUpdate
+from oteapi.utils._pydantic import Field, FileUrl
+from oteapi.utils._pydantic import dataclasses as pydantic_dataclasses
+from oteapi.utils._pydantic import validator
 from oteapi.utils.paths import uri_to_path
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -59,7 +59,7 @@ class SessionUpdateFile(SessionUpdate):
     key: str = Field(..., description="Key to access the data in the cache.")
 
 
-@dataclass
+@pydantic_dataclasses.dataclass
 class FileStrategy:
     """Strategy for retrieving data from a local file.
 

--- a/oteapi/strategies/download/https.py
+++ b/oteapi/strategies/download/https.py
@@ -3,11 +3,11 @@
 from typing import TYPE_CHECKING, Optional
 
 import requests
-from pydantic import AnyHttpUrl, Field
-from pydantic.dataclasses import dataclass
 
 from oteapi.datacache import DataCache
 from oteapi.models import AttrDict, DataCacheConfig, ResourceConfig, SessionUpdate
+from oteapi.utils._pydantic import AnyHttpUrl, Field
+from oteapi.utils._pydantic import dataclasses as pydantic_dataclasses
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Any, Dict
@@ -39,7 +39,7 @@ class SessionUpdateHTTPS(SessionUpdate):
     key: str = Field(..., description="Key to access the data in the cache.")
 
 
-@dataclass
+@pydantic_dataclasses.dataclass
 class HTTPSStrategy:
     """Strategy for retrieving data via http.
 

--- a/oteapi/strategies/download/sftp.py
+++ b/oteapi/strategies/download/sftp.py
@@ -5,11 +5,11 @@ from tempfile import NamedTemporaryFile
 from typing import TYPE_CHECKING, Optional
 
 import pysftp
-from pydantic import AnyUrl, Field
-from pydantic.dataclasses import dataclass
 
 from oteapi.datacache import DataCache
 from oteapi.models import AttrDict, DataCacheConfig, ResourceConfig, SessionUpdate
+from oteapi.utils._pydantic import AnyUrl, Field
+from oteapi.utils._pydantic import dataclasses as pydantic_dataclasses
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Any, Dict
@@ -47,7 +47,7 @@ class SessionUpdateSFTP(SessionUpdate):
     key: str = Field(..., description="Key to access the data in the cache.")
 
 
-@dataclass
+@pydantic_dataclasses.dataclass
 class SFTPStrategy:
     """Strategy for retrieving data via sftp.
 

--- a/oteapi/strategies/filter/crop_filter.py
+++ b/oteapi/strategies/filter/crop_filter.py
@@ -2,10 +2,9 @@
 # pylint: disable=unused-argument
 from typing import TYPE_CHECKING, Tuple
 
-from pydantic import Field
-from pydantic.dataclasses import dataclass
-
 from oteapi.models import AttrDict, FilterConfig, SessionUpdate
+from oteapi.utils._pydantic import Field
+from oteapi.utils._pydantic import dataclasses as pydantic_dataclasses
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Any, Dict, Optional
@@ -40,7 +39,7 @@ class SessionUpdateCropFilter(SessionUpdate):
     )
 
 
-@dataclass
+@pydantic_dataclasses.dataclass
 class CropImageFilter:
     """Strategy for cropping an image.
 

--- a/oteapi/strategies/filter/sql_query_filter.py
+++ b/oteapi/strategies/filter/sql_query_filter.py
@@ -2,10 +2,9 @@
 # pylint: disable=unused-argument
 from typing import TYPE_CHECKING
 
-from pydantic import Field
-from pydantic.dataclasses import dataclass
-
 from oteapi.models import FilterConfig, SessionUpdate
+from oteapi.utils._pydantic import Field
+from oteapi.utils._pydantic import dataclasses as pydantic_dataclasses
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Any, Dict, Optional
@@ -28,7 +27,7 @@ class SessionUpdateSqlQuery(SessionUpdate):
     sqlquery: str = Field(..., description="A SQL query string.")
 
 
-@dataclass
+@pydantic_dataclasses.dataclass
 class SQLQueryFilter:
     """Strategy for a SQL query filter.
 

--- a/oteapi/strategies/mapping/mapping.py
+++ b/oteapi/strategies/mapping/mapping.py
@@ -2,9 +2,9 @@
 # pylint: disable=unused-argument
 from typing import TYPE_CHECKING, Dict, List
 
-from pydantic.dataclasses import Field, dataclass
-
 from oteapi.models import MappingConfig, RDFTriple, SessionUpdate
+from oteapi.utils._pydantic import Field
+from oteapi.utils._pydantic import dataclasses as pydantic_dataclasses
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Any, Optional
@@ -26,7 +26,7 @@ class MappingSessionUpdate(SessionUpdate):
     )
 
 
-@dataclass
+@pydantic_dataclasses.dataclass
 class MappingStrategy:
     """Strategy for a mapping.
 

--- a/oteapi/strategies/parse/application_json.py
+++ b/oteapi/strategies/parse/application_json.py
@@ -3,12 +3,11 @@
 import json
 from typing import TYPE_CHECKING, Optional
 
-from pydantic import Field
-from pydantic.dataclasses import dataclass
-
 from oteapi.datacache import DataCache
 from oteapi.models import AttrDict, DataCacheConfig, ResourceConfig, SessionUpdate
 from oteapi.plugins import create_strategy
+from oteapi.utils._pydantic import Field
+from oteapi.utils._pydantic import dataclasses as pydantic_dataclasses
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Any, Dict
@@ -42,7 +41,7 @@ class SessionUpdateJSONParse(SessionUpdate):
     content: dict = Field(..., description="Content of the JSON document.")
 
 
-@dataclass
+@pydantic_dataclasses.dataclass
 class JSONDataParseStrategy:
     """Parse strategy for JSON.
 

--- a/oteapi/strategies/parse/application_vnd_sqlite.py
+++ b/oteapi/strategies/parse/application_vnd_sqlite.py
@@ -4,12 +4,11 @@ import sqlite3
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
-from pydantic import Field
-from pydantic.dataclasses import dataclass
-
 from oteapi.datacache import DataCache
 from oteapi.models import AttrDict, DataCacheConfig, ResourceConfig, SessionUpdate
 from oteapi.plugins import create_strategy
+from oteapi.utils._pydantic import Field
+from oteapi.utils._pydantic import dataclasses as pydantic_dataclasses
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Any, Dict
@@ -65,7 +64,7 @@ class SessionUpdateSqLiteParse(SessionUpdate):
     result: list = Field(..., description="List of results from the query.")
 
 
-@dataclass
+@pydantic_dataclasses.dataclass
 class SqliteParseStrategy:
     """Parse strategy for SQLite.
 

--- a/oteapi/strategies/parse/excel_xlsx.py
+++ b/oteapi/strategies/parse/excel_xlsx.py
@@ -4,11 +4,11 @@ from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
 from openpyxl import load_workbook
 from openpyxl.utils import column_index_from_string, get_column_letter
-from pydantic import Field
-from pydantic.dataclasses import dataclass
 
 from oteapi.datacache import DataCache
 from oteapi.models import AttrDict, DataCacheConfig, ParserConfig, SessionUpdate
+from oteapi.utils._pydantic import Field
+from oteapi.utils._pydantic import dataclasses as pydantic_dataclasses
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Any, Iterable
@@ -150,7 +150,7 @@ def get_column_indices(
     return range(model.col_from, model.col_to + 1)
 
 
-@dataclass
+@pydantic_dataclasses.dataclass
 class XLSXParseStrategy:
     """Parse strategy for Excel XLSX files.
 

--- a/oteapi/strategies/parse/image.py
+++ b/oteapi/strategies/parse/image.py
@@ -11,12 +11,12 @@ else:
 
 import numpy as np
 from PIL import Image
-from pydantic import Field
-from pydantic.dataclasses import dataclass
 
 from oteapi.datacache import DataCache
 from oteapi.models import AttrDict, DataCacheConfig, ResourceConfig, SessionUpdate
 from oteapi.plugins import create_strategy
+from oteapi.utils._pydantic import Field
+from oteapi.utils._pydantic import dataclasses as pydantic_dataclasses
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Any, Dict
@@ -114,7 +114,7 @@ class SessionUpdateImageParse(SessionUpdate):
     )
 
 
-@dataclass
+@pydantic_dataclasses.dataclass
 class ImageDataParseStrategy:
     """Parse strategy for images.
 

--- a/oteapi/strategies/parse/postgres.py
+++ b/oteapi/strategies/parse/postgres.py
@@ -4,10 +4,11 @@ from typing import Any, Dict, Optional
 from urllib.parse import urlunparse
 
 import psycopg
-from pydantic import AnyUrl, Field, parse_obj_as, root_validator
-from pydantic.dataclasses import dataclass
 
 from oteapi.models import AttrDict, DataCacheConfig, ResourceConfig, SessionUpdate
+from oteapi.utils._pydantic import AnyUrl, Field
+from oteapi.utils._pydantic import dataclasses as pydantic_dataclasses
+from oteapi.utils._pydantic import parse_obj_as, root_validator
 
 
 class PostgresConfig(AttrDict):
@@ -136,7 +137,7 @@ class SessionUpdatePostgresResource(SessionUpdate):
     result: list = Field(..., description="List of results from the query.")
 
 
-@dataclass
+@pydantic_dataclasses.dataclass
 class PostgresResourceStrategy:
     """Resource strategy for Postgres.
 

--- a/oteapi/strategies/parse/text_csv.py
+++ b/oteapi/strategies/parse/text_csv.py
@@ -5,12 +5,12 @@ from collections import defaultdict
 from enum import Enum
 from typing import Any, Hashable, Optional, Type, Union
 
-from pydantic import BaseModel, Field, validator
-from pydantic.dataclasses import dataclass
-
 from oteapi.datacache import DataCache
 from oteapi.models import AttrDict, DataCacheConfig, ResourceConfig, SessionUpdate
 from oteapi.plugins import create_strategy
+from oteapi.utils._pydantic import BaseModel, Field
+from oteapi.utils._pydantic import dataclasses as pydantic_dataclasses
+from oteapi.utils._pydantic import validator
 
 
 class QuoteConstants(str, Enum):
@@ -249,7 +249,7 @@ class SessionUpdateCSVParse(SessionUpdate):
     )
 
 
-@dataclass
+@pydantic_dataclasses.dataclass
 class CSVParseStrategy:
     """Parse strategy for CSV files.
 

--- a/oteapi/strategies/transformation/celery_remote.py
+++ b/oteapi/strategies/transformation/celery_remote.py
@@ -4,8 +4,6 @@ from typing import TYPE_CHECKING, Dict
 
 from celery import Celery
 from celery.result import AsyncResult
-from pydantic import Field
-from pydantic.dataclasses import dataclass
 
 from oteapi.models import (
     AttrDict,
@@ -13,6 +11,8 @@ from oteapi.models import (
     TransformationConfig,
     TransformationStatus,
 )
+from oteapi.utils._pydantic import Field
+from oteapi.utils._pydantic import dataclasses as pydantic_dataclasses
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Any, Optional, Union
@@ -70,7 +70,7 @@ class CeleryStrategyConfig(TransformationConfig):
     )
 
 
-@dataclass
+@pydantic_dataclasses.dataclass
 class CeleryRemoteStrategy:
     """Submit job to remote Celery runner.
 

--- a/oteapi/utils/_pydantic.py
+++ b/oteapi/utils/_pydantic.py
@@ -18,10 +18,10 @@ def get_pydantic_major_version() -> int:
 PYDANTIC_VERSION = get_pydantic_major_version()
 
 if PYDANTIC_VERSION == 1:
-    from pydantic import *
-    from pydantic.fields import Undefined
+    from pydantic import *  # noqa: F403
+    from pydantic.fields import Undefined  # noqa: F401
 elif PYDANTIC_VERSION == 2:
-    from pydantic.v1 import *
-    from pydantic.v1.fields import Undefined
+    from pydantic.v1 import *  # noqa: F403
+    from pydantic.v1.fields import Undefined  # type: ignore[no-redef]  # noqa: F401
 else:
     raise NotImplementedError("Support for pydantic version >=3 is not implemented.")

--- a/oteapi/utils/_pydantic.py
+++ b/oteapi/utils/_pydantic.py
@@ -1,0 +1,27 @@
+"""Import from pydantic through this module.
+
+This is to ensure compatibility with pydantic v1 and v2.
+"""
+
+
+def get_pydantic_major_version() -> int:
+    """Get the major version of pydantic.
+
+    Returns:
+        int: The major version of pydantic.
+    """
+    import pydantic
+
+    return int(pydantic.VERSION.split(".", maxsplit=1)[0])
+
+
+PYDANTIC_VERSION = get_pydantic_major_version()
+
+if PYDANTIC_VERSION == 1:
+    from pydantic import *
+    from pydantic.fields import Undefined
+elif PYDANTIC_VERSION == 2:
+    from pydantic.v1 import *
+    from pydantic.v1.fields import Undefined
+else:
+    raise NotImplementedError("Support for pydantic version >=3 is not implemented.")

--- a/oteapi/utils/paths.py
+++ b/oteapi/utils/paths.py
@@ -4,7 +4,7 @@ from pathlib import Path, PureWindowsPath
 from typing import TYPE_CHECKING
 from urllib.parse import ParseResult, urlparse
 
-from pydantic import AnyUrl
+from oteapi.utils._pydantic import AnyUrl
 
 if TYPE_CHECKING:  # pragma: no cover
     from typing import Union

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,12 +25,11 @@ dependencies = [
     "ase~=3.22.1",
     "celery>=5.2.3,<6",
     "diskcache>=5.4.0,<6",
-    "fastapi-plugins~=0.12.0",
     "numpy>=1.21,<2",
     "openpyxl>=3.0.9,<4",
     "Pillow>=9.0.0,<11",
     "psycopg~=3.1.10",
-    "pydantic>=1.9.0,<2",
+    "pydantic>=1.10.12,<3",
     "pysftp~=0.2.9",
     "requests>=2.26.0,<3",
     "typing-extensions~=4.8",
@@ -57,6 +56,7 @@ dev = [
     "pytest~=7.4",
     "pytest-celery",
     "pytest-cov~=4.1",
+    "redis~=5.0",
     "requests-mock~=1.11",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ exclude = [
     "tests/",
     ".gitignore",
     ".pre-commit-config.yaml",
+    ".codecov.yml",
 ]
 
 [tool.mypy]

--- a/tests/models/test_genericconfig.py
+++ b/tests/models/test_genericconfig.py
@@ -21,9 +21,8 @@ if TYPE_CHECKING:
 @pytest.fixture
 def generic_config() -> "CustomConfig":
     """Return a usable `CustomConfig` for test purposes."""
-    from pydantic import Field
-
     from oteapi.models.genericconfig import AttrDict, GenericConfig
+    from oteapi.utils._pydantic import Field
 
     class CustomConfiguration(AttrDict):
         """A custom AttrDict class to use as `configuration` in CustomConfig."""
@@ -125,7 +124,7 @@ def test_attribute_del_item(generic_config: "CustomConfig") -> None:
 
 def test_attribute_del_item_fail(generic_config: "CustomConfig") -> None:
     """Ensure KeyError is raised if key does not exist in AttrDict."""
-    from pydantic import ValidationError
+    from oteapi.utils._pydantic import ValidationError
 
     non_existent_key = "non_existant_key"
     assert non_existent_key not in generic_config.configuration
@@ -144,7 +143,7 @@ def test_attribute_del_item_fail(generic_config: "CustomConfig") -> None:
 
 def test_attribute_ne(generic_config: "CustomConfig") -> None:
     """Test configuration.__ne__()."""
-    from pydantic import BaseModel
+    from oteapi.utils._pydantic import BaseModel
 
     class Test(BaseModel):
         """Test pydantic model."""
@@ -173,9 +172,8 @@ def test_attrdict() -> None:
 
 def test_attrdict_update() -> None:
     """Test supplying `AttrDict.update()` with different (valid) types."""
-    from pydantic import BaseModel, Field
-
     from oteapi.models.genericconfig import AttrDict
+    from oteapi.utils._pydantic import BaseModel, Field
 
     class Foo(BaseModel):
         """Foo pydantic model."""

--- a/tests/models/test_resourceconfig.py
+++ b/tests/models/test_resourceconfig.py
@@ -4,9 +4,8 @@ import pytest
 
 def test_ensure_unique_url_pairs() -> None:
     """Test the root validator `ensure_unique_url_pairs` for `ResourceConfig`."""
-    from pydantic import ValidationError
-
     from oteapi.models.resourceconfig import ResourceConfig
+    from oteapi.utils._pydantic import ValidationError
 
     valid_parameters = {
         "downloadUrl": "http://example.org",

--- a/tests/static/strategies/download.py
+++ b/tests/static/strategies/download.py
@@ -2,15 +2,14 @@
 # pylint: disable=unused-argument
 from typing import TYPE_CHECKING
 
-from pydantic.dataclasses import dataclass
-
 from oteapi.models import ResourceConfig
+from oteapi.utils._pydantic import dataclasses as pydantic_dataclasses
 
 if TYPE_CHECKING:
     from typing import Any, Dict, Optional
 
 
-@dataclass
+@pydantic_dataclasses.dataclass
 class DownloadTestStrategy:
     """Test download strategy."""
 

--- a/tests/static/strategies/filter.py
+++ b/tests/static/strategies/filter.py
@@ -2,15 +2,14 @@
 # pylint: disable=unused-argument
 from typing import TYPE_CHECKING
 
-from pydantic.dataclasses import dataclass
-
 from oteapi.models import FilterConfig
+from oteapi.utils._pydantic import dataclasses as pydantic_dataclasses
 
 if TYPE_CHECKING:
     from typing import Any, Dict, Optional
 
 
-@dataclass
+@pydantic_dataclasses.dataclass
 class FilterTestStrategy:
     """Test filter strategy."""
 

--- a/tests/static/strategies/function.py
+++ b/tests/static/strategies/function.py
@@ -2,15 +2,14 @@
 # pylint: disable=unused-argument
 from typing import TYPE_CHECKING
 
-from pydantic.dataclasses import dataclass
-
 from oteapi.models import FunctionConfig
+from oteapi.utils._pydantic import dataclasses as pydantic_dataclasses
 
 if TYPE_CHECKING:
     from typing import Any, Dict, Optional
 
 
-@dataclass
+@pydantic_dataclasses.dataclass
 class FunctionTestStrategy:
     """Test function strategy."""
 

--- a/tests/static/strategies/mapping.py
+++ b/tests/static/strategies/mapping.py
@@ -2,15 +2,14 @@
 # pylint: disable=unused-argument
 from typing import TYPE_CHECKING
 
-from pydantic.dataclasses import dataclass
-
 from oteapi.models import MappingConfig
+from oteapi.utils._pydantic import dataclasses as pydantic_dataclasses
 
 if TYPE_CHECKING:
     from typing import Any, Dict, Optional
 
 
-@dataclass
+@pydantic_dataclasses.dataclass
 class MappingTestStrategy:
     """Test mapping strategy."""
 

--- a/tests/static/strategies/parse.py
+++ b/tests/static/strategies/parse.py
@@ -2,15 +2,14 @@
 # pylint: disable=unused-argument
 from typing import TYPE_CHECKING
 
-from pydantic.dataclasses import dataclass
-
 from oteapi.models import ResourceConfig
+from oteapi.utils._pydantic import dataclasses as pydantic_dataclasses
 
 if TYPE_CHECKING:
     from typing import Any, Dict, Optional
 
 
-@dataclass
+@pydantic_dataclasses.dataclass
 class ParseTestStrategy:
     """Test parse strategy."""
 

--- a/tests/static/strategies/resource.py
+++ b/tests/static/strategies/resource.py
@@ -2,15 +2,14 @@
 # pylint: disable=unused-argument
 from typing import TYPE_CHECKING
 
-from pydantic.dataclasses import dataclass
-
 from oteapi.models import ResourceConfig
+from oteapi.utils._pydantic import dataclasses as pydantic_dataclasses
 
 if TYPE_CHECKING:
     from typing import Any, Dict, Optional
 
 
-@dataclass
+@pydantic_dataclasses.dataclass
 class ResourceTestStrategy:
     """Test resource strategy."""
 

--- a/tests/static/strategies/transformation.py
+++ b/tests/static/strategies/transformation.py
@@ -2,15 +2,14 @@
 # pylint: disable=unused-argument
 from typing import TYPE_CHECKING
 
-from pydantic.dataclasses import dataclass
-
 from oteapi.models import TransformationConfig, TransformationStatus
+from oteapi.utils._pydantic import dataclasses as pydantic_dataclasses
 
 if TYPE_CHECKING:
     from typing import Any, Dict, Optional
 
 
-@dataclass
+@pydantic_dataclasses.dataclass
 class TransformationTestStrategy:
     """Test transformation strategy."""
 

--- a/tests/strategies/parse/test_text_csv.py
+++ b/tests/strategies/parse/test_text_csv.py
@@ -145,10 +145,9 @@ def test_csv_dialect_enum_fails() -> None:
     """Test `CSVDialect` is created properly and raises for invalid dialect Enum."""
     import csv
 
-    from pydantic import ValidationError
-
     from oteapi.models.resourceconfig import ResourceConfig
     from oteapi.strategies.parse.text_csv import CSVParseStrategy
+    from oteapi.utils._pydantic import ValidationError
 
     non_existant_dialect = "test"
     available_dialects = csv.list_dialects()

--- a/tests/strategies/transformation/test_celery_remote.py
+++ b/tests/strategies/transformation/test_celery_remote.py
@@ -18,9 +18,10 @@ def celery_config() -> dict[str, str]:
 
     host = os.getenv("OTEAPI_REDIS_HOST", "localhost")
     port = int(os.getenv("OTEAPI_REDIS_PORT", "6379"))
-    client = redis.Redis(host=host, port=port)
+
     try:
-        client.ping()
+        with redis.Redis(host=host, port=port) as client:
+            client.ping()
     except redis.ConnectionError:
         if os.getenv("CI") and platform.system() == "Linux":
             # Starting services (like redis) is only supported in GH Actions for the

--- a/tests/utils/test_paths.py
+++ b/tests/utils/test_paths.py
@@ -7,8 +7,7 @@ def test_uri_to_path() -> None:
     from pathlib import Path
     from urllib.parse import urlparse
 
-    from pydantic import BaseModel, FileUrl
-
+    from oteapi.utils._pydantic import BaseModel, FileUrl
     from oteapi.utils.paths import uri_to_path
 
     class MyModel(BaseModel):


### PR DESCRIPTION
# Description:
<!-- Summary of change, including the issue to be addressed. -->
Closes #308 

This PR can be considered a temporary stage in-between moving from v1 to v2 of pydantic.
PR #330 properly implements usage of pydantic v2, thereby making it almost impossible to also support v1. This PR, on the other hand, utilizes the fact that the v1 API still exists within pydantic v2 (under the `v1` module, i.e., `from pydantic import ...` in v1 is equivalent to `from pydantic.v1 import ...` in v2.
To support both v1 and v2, this fact has been taken full advantage of by creating a `_pydantic` module under `oteapi.utils` which one can import pydantic stuff from and it will automatically redirect to the correct submodule depending on the pydantic version actually installed on the system.

Note, I'd like to repeat: this implementation should be considered _**temporary**_. The changes in #330 should be implemented over time, when we're sure this doesn't break any relevant plugins.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
