### PR TITLE
Sort dependencies

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -15,18 +15,10 @@ coverage:
         threshold: 1%
         flags:
           - linux
-      linux-extra_libs:
-        threshold: 1%
-        flags:
-          - linux-extra_libs
       windows:
         threshold: 1%
         flags:
           - windows
-      windows-extra_libs:
-        threshold: 1%
-        flags:
-          - windows-extra_libs
       linux-strategies:
         threshold: 1%
         flags:

--- a/.github/workflows/ci_cd_updated_master.yml
+++ b/.github/workflows/ci_cd_updated_master.yml
@@ -42,5 +42,8 @@ jobs:
         (oteapi/models/functionconfig.py),[oteapi.models.functionconfig.FunctionConfig.functionType]
         (oteapi/models/mappingconfig.py),[oteapi.models.mappingconfig.MappingConfig.mappingType]
         (oteapi/models/transformationconfig.py),[oteapi.models.transformationconfig.TransformationConfig.transformationType]
+      exclude_files: |
+        __init__.py
+        _pydantic.py
     secrets:
       PAT: ${{ secrets.RELEASE_PAT }}

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -96,21 +96,10 @@ jobs:
       run: |
         python -m pip install -U pip
         pip install -U setuptools wheel
-        pip install -e .[dev]
+        pip install -e .[testing]
 
     - name: Test with pytest
-      run: pytest -vvv --cov-report=xml --cov=oteapi --durations=10
-
-    - name: Upload coverage to Codecov
-      if: matrix.python-version == '3.9' && github.repository == 'EMMC-ASBL/oteapi-core'
-      uses: codecov/codecov-action@v3
-      with:
-        files: coverage.xml
-        flags: linux
-
-    - name: Test with optional libs
       run: |
-        pip install ase numpy
         pytest -vvv --cov-report=xml --cov=oteapi --durations=10
         pytest --cov-report=xml:strategies.xml --cov=oteapi/strategies --durations=10
 
@@ -119,7 +108,7 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         files: coverage.xml
-        flags: linux-extra_libs
+        flags: linux
 
     - name: Upload strategies coverage to Codecov
       if: matrix.python-version == '3.9' && github.repository == 'EMMC-ASBL/oteapi-core'
@@ -158,21 +147,10 @@ jobs:
       run: |
         python -m pip install -U pip
         pip install -U setuptools wheel
-        pip install -e .[dev]
+        pip install -e .[testing]
 
     - name: Test with pytest
-      run: pytest -vvv --cov-report=xml --cov=oteapi --durations=10
-
-    - name: Upload coverage to Codecov
-      if: matrix.python-version == '3.9' && github.repository == 'EMMC-ASBL/oteapi-core'
-      uses: codecov/codecov-action@v3
-      with:
-        files: coverage.xml
-        flags: windows
-
-    - name: Test with optional libs
       run: |
-        pip install ase numpy
         pytest -vvv --cov-report=xml --cov=oteapi --durations=10
         pytest --cov-report=xml:strategies.xml --cov=oteapi/strategies --durations=10
 
@@ -181,7 +159,7 @@ jobs:
       uses: codecov/codecov-action@v3
       with:
         files: coverage.xml
-        flags: windows-extra_libs
+        flags: windows
 
     - name: Upload strategies coverage to Codecov
       if: matrix.python-version == '3.9' && github.repository == 'EMMC-ASBL/oteapi-core'

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -52,6 +52,9 @@ jobs:
         (oteapi/models/functionconfig.py),[oteapi.models.functionconfig.FunctionConfig.functionType]
         (oteapi/models/mappingconfig.py),[oteapi.models.mappingconfig.MappingConfig.mappingType]
         (oteapi/models/transformationconfig.py),[oteapi.models.transformationconfig.TransformationConfig.transformationType]
+      exclude_files: |
+        __init__.py
+        _pydantic.py
       warnings_as_errors: true
 
   ruff:

--- a/docs/api_reference/utils/_pydantic.md
+++ b/docs/api_reference/utils/_pydantic.md
@@ -1,3 +1,0 @@
-# _pydantic
-
-::: oteapi.utils._pydantic

--- a/oteapi/strategies/parse/image.py
+++ b/oteapi/strategies/parse/image.py
@@ -8,7 +8,6 @@ if sys.version_info >= (3, 10):
 else:
     from typing_extensions import Literal
 
-import numpy as np
 from PIL import Image
 from pydantic import Field
 from pydantic.dataclasses import dataclass
@@ -194,18 +193,14 @@ class ImageDataParseStrategy:
                         {"version": image.info.get("version", b"")[len(b"GIF") :]}
                     )
 
-            # Use the buffer protocol to store the image in the datacache
-            data = np.asarray(image)
             image_key = cache.add(
-                data,
+                image.tobytes(),
                 key=config.image_key,
                 tag=str(id(session)),
             )
 
             if image.mode == "P":
-                image_palette_key = cache.add(
-                    np.asarray(image.getpalette()), tag=str(id(session))
-                )
+                image_palette_key = cache.add(image.getpalette(), tag=str(id(session)))
             else:
                 image_palette_key = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,19 +21,20 @@ requires-python = ">=3.9"
 dynamic = ["version"]
 
 dependencies = [
+    # Core dependencies
     "agraph-python>=101.0.7,<103",
-    "ase~=3.22.1",
-    "celery>=5.2.3,<6",
     "diskcache>=5.4.0,<6",
-    "fastapi-plugins~=0.12.0",
+    "pydantic>=1.9.0,<2",
+    "typing-extensions~=4.8; python_version<'3.10'",
+
+    # Strategy dependencies
+    "celery>=5.2.3,<6",
     "numpy>=1.21,<2",
     "openpyxl>=3.0.9,<4",
     "Pillow>=9.0.0,<11",
     "psycopg~=3.1.10",
-    "pydantic>=1.9.0,<2",
     "pysftp~=0.2.9",
     "requests>=2.26.0,<3",
-    "typing-extensions~=4.8",
     "urllib3<2",
 ]
 
@@ -45,18 +46,28 @@ docs = [
     "mkdocs-material~=9.3",
     "mkdocstrings[python]~=0.23.0",
 ]
+testing = [
+    "ase~=3.22.1",
+    "pytest~=7.4",
+    "pytest-celery",
+    "pytest-cov~=4.1",
+    "redis~=5.0",
+    "requests-mock~=1.11",
+]
 dev = [
     "mike~=1.1",
     "mkdocs~=1.5",
     "mkdocs-awesome-pages-plugin~=2.9",
     "mkdocs-material~=9.3",
     "mkdocstrings[python]~=0.23.0",
-    "pre-commit>=2.21.0,<3; python_version<'3.8'",
-    "pre-commit~=3.4; python_version>='3.8'",
+    "ase~=3.22.1",
     "pytest~=7.4",
     "pytest-celery",
     "pytest-cov~=4.1",
+    "redis~=5.0",
     "requests-mock~=1.11",
+    "pre-commit>=2.21.0,<3; python_version<'3.8'",
+    "pre-commit~=3.4; python_version>='3.8'",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
 
     # Strategy dependencies
     "celery>=5.2.3,<6",
-    "numpy>=1.21,<2",
     "openpyxl>=3.0.9,<4",
     "Pillow>=9.0.0,<11",
     "psycopg~=3.1.10",
@@ -48,6 +47,7 @@ docs = [
 ]
 testing = [
     "ase~=3.22.1",
+    "numpy>=1.21,<2",
     "pytest~=7.4",
     "pytest-celery",
     "pytest-cov~=4.1",
@@ -61,6 +61,7 @@ dev = [
     "mkdocs-material~=9.3",
     "mkdocstrings[python]~=0.23.0",
     "ase~=3.22.1",
+    "numpy>=1.21,<2",
     "pytest~=7.4",
     "pytest-celery",
     "pytest-cov~=4.1",

--- a/tests/strategies/filter/test_crop_filter.py
+++ b/tests/strategies/filter/test_crop_filter.py
@@ -13,6 +13,9 @@ def test_crop_filter(static_files: "Path") -> None:
     Note: This test incorporates much of the contents of the test
     'test_jpeg.py', so if that test fails, this one should fail too.
     """
+    import numpy as np
+    from PIL import Image
+
     from oteapi.datacache import DataCache
     from oteapi.strategies.filter.crop_filter import CropImageFilter
     from oteapi.strategies.parse.image import ImageDataParseStrategy
@@ -46,6 +49,12 @@ def test_crop_filter(static_files: "Path") -> None:
 
     try:
         data = cache.get(image_key)
-        assert data.shape == (400, 700, 3)
     finally:
         del cache[image_key]
+
+    data = np.asarray(
+        Image.frombytes(
+            data=data, mode=session["image_mode"], size=session["image_size"]
+        )
+    )
+    assert data.shape == (400, 700, 3)

--- a/tests/strategies/parse/test_image.py
+++ b/tests/strategies/parse/test_image.py
@@ -35,6 +35,7 @@ def test_image(
     static_files: "Path",
 ) -> None:
     """Test parsing an image format."""
+
     import numpy as np
     from PIL import Image
 
@@ -101,6 +102,12 @@ def test_image(
             data = cache.get(image_key)
         finally:
             del cache[image_key]
+
+        data = np.asarray(
+            Image.frombytes(
+                data=data, mode=session["image_mode"], size=session["image_size"]
+            )
+        )
 
         if crop:
             mode = session["image_mode"]


### PR DESCRIPTION
# Description:
<!-- Summary of change, including the issue to be addressed. -->
**Motivation**: I didn't understand why oteapi-core needs `ase` as a standard dependency, let's see what's really going on here.
**Result**: Sort the dependencies according to usage.

Things done here:
- Create a new "testing" extra that can be installed to ensure one has all the extra packages necessary for running `pytest`.
- Move `ase` to "testing" (and "dev").
- Remove `fastapi-plugins` in favor of adding redis to "testing" (and "dev"). It is not actually used elsewhere.
- Only install typing-extensions for Python <3.10.
- Split core dependencies visually in `pyproject.toml` between what is "core" and which dependencies are only for the strategies. As a note on this, there seems to be a LOT more dependencies only used for the strategies (unsurprisingly when thinking about it).
- Move `numpy` to "testing" (and "dev"). This was achieved by storing the image as bytes in the datacache instead of as a numpy array. The tests still creates a numpy array from these bytes through loading the image again using the Pillow library.

Finally, it seemed the pytest jobs running in the CI were actually slightly outdated. They are currently split in two (for each of the OS'), where the tests are run and then "extra libs" are installed, i.e., `ase` and `numpy`, and then the tests are run again. However, `ase` and `numpy` have up until now been part of the core dependencies being installed, so there was really no different between these two test runs. With the update and movement of dependencies, we're still installing `ase` and `numpy` from the get go, and as such there is no need for this test run split, so it has been removed.
This also minimizes the recently introduced list of codecov flags from 6 to 4. Nice :)

**For the future**: It might be interesting to minimize or separate out the strategies in this repository to a separate repository in order to keep the actual dependencies installed when using the core elements of OTEAPI to a minimum.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
