### PR TITLE
Update release and tests CI/CD workflows

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   publish:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/cd_release.yml@v2.5.1
+    uses: SINTEF/ci-cd/.github/workflows/cd_release.yml@v2.5.2
     if: github.repository == 'EMMC-ASBL/oteapi-core' && startsWith(github.ref, 'refs/tags/v0.5.')
     with:
       # General

--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -9,12 +9,12 @@ jobs:
   publish:
     name: External
     uses: SINTEF/ci-cd/.github/workflows/cd_release.yml@v2.5.1
-    if: github.repository == 'EMMC-ASBL/oteapi-core' && startsWith(github.ref, 'refs/tags/v')
+    if: github.repository == 'EMMC-ASBL/oteapi-core' && startsWith(github.ref, 'refs/tags/v0.5.')
     with:
       # General
       git_username: "TEAM 4.0[bot]"
       git_email: "Team4.0@SINTEF.no"
-      release_branch: master
+      release_branch: release/pydantic-v1-support
 
       # Publish to PyPI
       python_package: true
@@ -29,6 +29,7 @@ jobs:
       update_docs: true
       python_version_docs: "3.9"
       doc_extras: "[docs]"
+      mkdocs_update_latest: false
     secrets:
       PyPI_token: ${{ secrets.PYPI_TOKEN }}
       PAT: ${{ secrets.RELEASE_PAT }}

--- a/.github/workflows/ci_automerge_dependabot.yml
+++ b/.github/workflows/ci_automerge_dependabot.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   update-dependabot-branch:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/ci_automerge_prs.yml@v2.5.1
+    uses: SINTEF/ci-cd/.github/workflows/ci_automerge_prs.yml@v2.5.2
     if: github.repository_owner == 'EMMC-ASBL' && startsWith(github.event.pull_request.head.ref, 'dependabot/') && github.actor == 'dependabot[bot]'
     secrets:
       PAT: ${{ secrets.RELEASE_PAT }}

--- a/.github/workflows/ci_cd_updated_master.yml
+++ b/.github/workflows/ci_cd_updated_master.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   updates-to-master:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/ci_cd_updated_default_branch.yml@v2.5.1
+    uses: SINTEF/ci-cd/.github/workflows/ci_cd_updated_default_branch.yml@v2.5.2
     if: github.repository_owner == 'EMMC-ASBL'
     with:
       # General

--- a/.github/workflows/ci_check_dependencies.yml
+++ b/.github/workflows/ci_check_dependencies.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   check-dependencies:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/ci_check_pyproject_dependencies.yml@v2.5.1
+    uses: SINTEF/ci-cd/.github/workflows/ci_check_pyproject_dependencies.yml@v2.5.2
     if: github.repository_owner == 'EMMC-ASBL'
     with:
       git_username: "TEAM 4.0[bot]"

--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   create-collected-pr:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/ci_update_dependencies.yml@v2.5.1
+    uses: SINTEF/ci-cd/.github/workflows/ci_update_dependencies.yml@v2.5.2
     if: github.repository_owner == 'EMMC-ASBL'
     with:
       # General

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -6,6 +6,7 @@ on:
     branches:
       - 'master'
       - 'push-action/**'  # Allow pushing to protected branches (using CasperWA/push-protected)
+      - 'release/pydantic-v1-support'
 
 jobs:
   basic_tests:

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   basic_tests:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/ci_tests.yml@v2.5.1
+    uses: SINTEF/ci-cd/.github/workflows/ci_tests.yml@v2.5.2
     with:
       # pre-commit
       run_pre-commit: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,7 +51,7 @@ repos:
       - "pydantic<2"
 
   - repo: https://github.com/SINTEF/ci-cd
-    rev: v2.5.1
+    rev: v2.5.2
     hooks:
     - id: docs-api-reference
       args:


### PR DESCRIPTION
# Description:
<!-- Summary of change, including the issue to be addressed. -->
Closes #347 

### CD - Release workflow

Ensure release workflow only runs from 'release/pydantic-v1-support' branch when doing a v0.5.x release.
Change release_branch name to 'release/pydantic-v1-support' in order to update this branch with the commit that the new versioned tag is pointing to. This will never be part of the 'master' branch.
Add new input to ensure the 'latest' "version" is not updated in the documentation. Note, this new input is not yet available, but will be available in SINTEF/ci-cd > v2.5.1.

### CI - Tests

Ensure the tests are run upon pushes to 'release/pydantic-v1-support' to mimic the behaviour of 'master' as best as possible.

---

Waiting on a new release of [SINTEF/ci-cd](https://SINTEF.github.io/ci-cd) that includes the feature described in SINTEF/ci-cd#187.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
