### PR TITLE
Update CI/CD workflows for updating dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@ updates:
     interval: weekly
     day: monday
     time: "05:18"
-  # Should be bigger than or equal to the total number of dependencies (currently 19)
+  # Should be bigger than or equal to the total number of dependencies (currently 25)
   open-pull-requests-limit: 30
   target-branch: ci/dependabot-updates
   labels:
@@ -17,5 +17,27 @@ updates:
     interval: daily
     time: "05:24"
   target-branch: ci/dependabot-updates
+  labels:
+    - CI/CD
+
+# For pydantic v1 support branch - Should be removed after this is no longer being
+# supported (end of 2023)
+- package-ecosystem: pip
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: monday
+    time: "04:18"
+  # Should be bigger than or equal to the total number of dependencies (currently 25)
+  open-pull-requests-limit: 30
+  target-branch: release/pydantic-v1-support
+  labels:
+    - CI/CD
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "04:24"
+  target-branch: release/pydantic-v1-support
   labels:
     - CI/CD

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,8 @@
+# The dependabot checks are set on a schedule to run weekly and daily.
+# The time of day is set to be early in the morning to avoid working hours.
+# Furthermore, the time is set arbitrarily to avoid the general "high tide"
+# of all GH Actions being run at the top of the hour.
+
 version: 2
 updates:
 - package-ecosystem: pip

--- a/.github/workflows/ci_check_dependencies.yml
+++ b/.github/workflows/ci_check_dependencies.yml
@@ -1,14 +1,11 @@
-# This workflow consists of two "equal" jobs, updating the dependencies in
+# This workflow consists of two "equal" jobs that each update the dependencies in
 # `pyproject.toml` for the two different pydantic v1 and v2 development branches.
 
-# Essentially:
-# - When triggered by a schedule event, run both jobs.
-#   This will create 2 PRs: One against 'ci/dependabot-updates' and one against
-#   'release/pydantic-v1-support'.
-# - When triggered manually (workflow_dispatch), run only the job that corresponds
-#   to the user input "target_branch".
-#   This will create 1 PR: Either against 'ci/dependabot-updates' or against
-#   'release/pydantic-v1-support'.
+# Trigger Details:
+# - Scheduled event: Both jobs run, resulting in 2 PRs targeting
+#   'ci/dependabot-updates' and 'release/pydantic-v1-support'.
+# - Manual trigger (workflow_dispatch): Runs the job matching the user's
+#   "target_branch" input, creating 1 PR.
 
 # The documentation for the callable workflow is here:
 # https://sintef.github.io/ci-cd/latest/workflows/ci_check_pyproject_dependencies
@@ -38,10 +35,10 @@ jobs:
   check-dependencies:
     name: External
     uses: SINTEF/ci-cd/.github/workflows/ci_check_pyproject_dependencies.yml@v2.5.1
-    # Always only run this job if we're on the "origin" repository.
-    # If the workflow is triggered by a schedule event, run it no matter what.
-    # If the workflow is triggered manually (workflow_dispatch),
-    # ONLY run it if the user input "target_branch" is "ci/dependabot-updates".
+    # Job Execution Criteria:
+    # - It must be executed within the "origin" repository (EMMC-ASBL).
+    # - Always run for scheduled events.
+    # - For manual triggers, it runs only if "target_branch" is "ci/dependabot-updates".
     if: github.repository_owner == 'EMMC-ASBL' && ( github.event_name == 'schedule' || inputs.target_branch == 'ci/dependabot-updates' )
     with:
       git_username: "TEAM 4.0[bot]"
@@ -66,10 +63,10 @@ jobs:
   check-dependencies-release_pydantic-v1-support:
     name: External
     uses: SINTEF/ci-cd/.github/workflows/ci_check_pyproject_dependencies.yml@v2.5.1
-    # Always only run this job if we're on the "origin" repository.
-    # If the workflow is triggered by a schedule event, run it no matter what.
-    # If the workflow is triggered manually (workflow_dispatch),
-    # ONLY run it if the user input "target_branch" is "release/pydantic-v1-support".
+    # Job Execution Criteria:
+    # - It must be executed within the "origin" repository (EMMC-ASBL).
+    # - Always run for scheduled events.
+    # - For manual triggers, it runs only if "target_branch" is "release/pydantic-v1-support".
     if: github.repository_owner == 'EMMC-ASBL' && ( github.event_name == 'schedule' || inputs.target_branch == 'release/pydantic-v1-support' )
     with:
       git_username: "TEAM 4.0[bot]"

--- a/.github/workflows/ci_check_dependencies.yml
+++ b/.github/workflows/ci_check_dependencies.yml
@@ -4,6 +4,15 @@ on:
   schedule:
     - cron: "30 5 * * 1"
   workflow_dispatch:
+    inputs:
+      target_branch:
+        description: "Target branch"
+        required: true
+        default: "ci/dependabot-updates"
+        type: choice
+        options:
+          - ci/dependabot-updates
+          - release/pydantic-v1-support
 
 jobs:
   check-dependencies:
@@ -13,7 +22,7 @@ jobs:
     with:
       git_username: "TEAM 4.0[bot]"
       git_email: "Team4.0@SINTEF.no"
-      permanent_dependencies_branch: ci/dependabot-updates
+      permanent_dependencies_branch: ${{ inputs.target_branch }}
       python_version: "3.9"
       install_extras: "dev"
       pr_labels: "CI/CD"

--- a/.github/workflows/ci_check_dependencies.yml
+++ b/.github/workflows/ci_check_dependencies.yml
@@ -1,3 +1,23 @@
+# This workflow consists of two "equal" jobs, updating the dependencies in
+# `pyproject.toml` for the two different pydantic v1 and v2 development branches.
+
+# Essentially:
+# - When triggered by a schedule event, run both jobs.
+#   This will create 2 PRs: One against 'ci/dependabot-updates' and one against
+#   'release/pydantic-v1-support'.
+# - When triggered manually (workflow_dispatch), run only the job that corresponds
+#   to the user input "target_branch".
+#   This will create 1 PR: Either against 'ci/dependabot-updates' or against
+#   'release/pydantic-v1-support'.
+
+# The documentation for the callable workflow is here:
+# https://sintef.github.io/ci-cd/latest/workflows/ci_check_pyproject_dependencies
+
+# IMPORTANT: The "ignore" rules here are explicit and extensive due to a bug in
+#   SINTEF/ci-cd that doesn't respect version specifier constraints. See
+#   https://github.com/SINTEF/ci-cd/issues/141 for more information.
+#   The "ignore" rules ensure the explicit upper version limit is respected.
+
 name: CI - Check dependencies
 
 on:
@@ -18,6 +38,10 @@ jobs:
   check-dependencies:
     name: External
     uses: SINTEF/ci-cd/.github/workflows/ci_check_pyproject_dependencies.yml@v2.5.1
+    # Always only run this job if we're on the "origin" repository.
+    # If the workflow is triggered by a schedule event, run it no matter what.
+    # If the workflow is triggered manually (workflow_dispatch),
+    # ONLY run it if the user input "target_branch" is "ci/dependabot-updates".
     if: github.repository_owner == 'EMMC-ASBL' && ( github.event_name == 'schedule' || inputs.target_branch == 'ci/dependabot-updates' )
     with:
       git_username: "TEAM 4.0[bot]"
@@ -27,14 +51,14 @@ jobs:
       install_extras: "dev"
       pr_labels: "CI/CD"
       ignore: |
-        dependency-name=agraph-python...version=>101.0.7
-        dependency-name=celery...version==>=6
-        dependency-name=diskcache...version==>=6
-        dependency-name=numpy...version==>=2
-        dependency-name=openpyxl...version==>=4
-        dependency-name=Pillow...version==>=11
-        dependency-name=pydantic...version==>=2
-        dependency-name=requests...version==>=3
+        dependency-name=agraph-python...version=>=103
+        dependency-name=celery...version=>=6
+        dependency-name=diskcache...version=>=6
+        dependency-name=numpy...version=>=2
+        dependency-name=openpyxl...version=>=4
+        dependency-name=Pillow...version=>=11
+        dependency-name=pydantic...version=>=2
+        dependency-name=requests...version=>=3
         dependency-name=urllib3
     secrets:
       PAT: ${{ secrets.RELEASE_PAT }}
@@ -42,6 +66,10 @@ jobs:
   check-dependencies-release_pydantic-v1-support:
     name: External
     uses: SINTEF/ci-cd/.github/workflows/ci_check_pyproject_dependencies.yml@v2.5.1
+    # Always only run this job if we're on the "origin" repository.
+    # If the workflow is triggered by a schedule event, run it no matter what.
+    # If the workflow is triggered manually (workflow_dispatch),
+    # ONLY run it if the user input "target_branch" is "release/pydantic-v1-support".
     if: github.repository_owner == 'EMMC-ASBL' && ( github.event_name == 'schedule' || inputs.target_branch == 'release/pydantic-v1-support' )
     with:
       git_username: "TEAM 4.0[bot]"
@@ -51,14 +79,14 @@ jobs:
       install_extras: "dev"
       pr_labels: "CI/CD,pydantic-v1"
       ignore: |
-        dependency-name=agraph-python...version=>101.0.7
-        dependency-name=celery...version==>=6
-        dependency-name=diskcache...version==>=6
-        dependency-name=numpy...version==>=2
-        dependency-name=openpyxl...version==>=4
-        dependency-name=Pillow...version==>=11
-        dependency-name=pydantic...version==>=2
-        dependency-name=requests...version==>=3
+        dependency-name=agraph-python...version=>=103
+        dependency-name=celery...version=>=6
+        dependency-name=diskcache...version=>=6
+        dependency-name=numpy...version=>=2
+        dependency-name=openpyxl...version=>=4
+        dependency-name=Pillow...version=>=11
+        dependency-name=pydantic...version=>=2
+        dependency-name=requests...version=>=3
         dependency-name=urllib3
     secrets:
       PAT: ${{ secrets.RELEASE_PAT }}

--- a/.github/workflows/ci_check_dependencies.yml
+++ b/.github/workflows/ci_check_dependencies.yml
@@ -18,14 +18,38 @@ jobs:
   check-dependencies:
     name: External
     uses: SINTEF/ci-cd/.github/workflows/ci_check_pyproject_dependencies.yml@v2.5.1
-    if: github.repository_owner == 'EMMC-ASBL'
+    if: github.repository_owner == 'EMMC-ASBL' && ( github.event_name == 'schedule' || inputs.target_branch == 'ci/dependabot-updates' )
     with:
       git_username: "TEAM 4.0[bot]"
       git_email: "Team4.0@SINTEF.no"
-      permanent_dependencies_branch: ${{ inputs.target_branch }}
+      permanent_dependencies_branch: ci/dependabot-updates
       python_version: "3.9"
       install_extras: "dev"
       pr_labels: "CI/CD"
+      ignore: |
+        dependency-name=agraph-python...version=>101.0.7
+        dependency-name=celery...version==>=6
+        dependency-name=diskcache...version==>=6
+        dependency-name=numpy...version==>=2
+        dependency-name=openpyxl...version==>=4
+        dependency-name=Pillow...version==>=11
+        dependency-name=pydantic...version==>=2
+        dependency-name=requests...version==>=3
+        dependency-name=urllib3
+    secrets:
+      PAT: ${{ secrets.RELEASE_PAT }}
+
+  check-dependencies-release_pydantic-v1-support:
+    name: External
+    uses: SINTEF/ci-cd/.github/workflows/ci_check_pyproject_dependencies.yml@v2.5.1
+    if: github.repository_owner == 'EMMC-ASBL' && ( github.event_name == 'schedule' || inputs.target_branch == 'release/pydantic-v1-support' )
+    with:
+      git_username: "TEAM 4.0[bot]"
+      git_email: "Team4.0@SINTEF.no"
+      permanent_dependencies_branch: release/pydantic-v1-support
+      python_version: "3.9"
+      install_extras: "dev"
+      pr_labels: "CI/CD,pydantic-v1"
       ignore: |
         dependency-name=agraph-python...version=>101.0.7
         dependency-name=celery...version==>=6


### PR DESCRIPTION
# Description:
<!-- Summary of change, including the issue to be addressed. -->
Closes #349 

### Dependabot

Repeat the jobs with 'release/pydantic-v1-support' as the target branch.

### CI - Check dependencies

Add a user input when manually running the workflow to determine the target branch to check pyproject.toml dependencies in as well as open a PR against.

Add a new job to also run the callable SINTEF/ci-cd workflow against the 'release/pydantic-v1-support' branch.
Change the use of the `workflow_dispatch` input 'target_branch' so that it's checked against the triggering event being 'schedule'.

Essentially, now:
- When triggered by 'schedule', both jobs should run, creating 2 PRs, one against 'ci/dependabot-updates' & one against
'release/pydantic-v1-support'.
- When manually triggered, only one of the jobs should run, creating either a PR against 'ci/dependabot-updates' OR against 'release/pydantic-v1-support'.

Both jobs should always still only run for the original repository, i.e., not for forks - this is unchanged from previous iterations.

### Future

Changes are already in the works for the ignore rules in _CI - Check dependencies_ when migrating to pydantic v2 (see #330), the split into two CI jobs here will accommodate this difference as well.
This means, depending on the merge order, either _this_ PR or #330 should be updated accordingly.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
