### PR TITLE
Implement PEP 508 regex for package_name

### DIFF
--- a/oteapi/plugins/entry_points.py
+++ b/oteapi/plugins/entry_points.py
@@ -174,8 +174,15 @@ class EntryPointStrategy:
     """
 
     ENTRY_POINT_NAME_REGEX = re.compile(
-        r"^(?P<package_name>[a-z_]+)\.(?P<strategy_name>.+)$"
+        r"^(?P<package_name>[A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9._-]*[A-Za-z0-9])\.(?P<strategy_name>.+)$"
     )
+    """Regex for entry point names.
+
+    The package_name group is a valid non-normalized package name regex adapted from
+    PEP 508.
+    For more information, see: https://peps.python.org/pep-0508/#names.
+    """
+
     ENTRY_POINT_NAME_SEPARATOR = ":"
 
     def __init__(self, entry_point: "EntryPoint") -> None:

--- a/tests/plugins/test_entry_points_entrypointstrategy.py
+++ b/tests/plugins/test_entry_points_entrypointstrategy.py
@@ -43,18 +43,31 @@ def test_entry_point_name_syntax(
     # Invalid entry points:
     # - Entry name doesn't start with package name.
     # - Wrong package + strategy type value separator
+    # - Invalid package name (must start/end with a letter or number)
     invalid_entry_points = """\
 oteapi.download =
   test = test_package:TestStrategy
 oteapi.parse =
   test_package:test = test_package:TestStrategy
+oteapi.mapping =
+  _test_package.test = test_package:TestStrategy
 """
 
     # Edge-case entry points:
     # - Weird chars for strategy value
+    # - Valid non-normalized package names
     edge_case_entry_points = """\
 oteapi.download =
   package.$t/\\123## = package.weird.name.chars:Test
+oteapi.parse =
+  Friendly-Bard.test = friendly_bard:TestStrategy
+  FRIENDLY-BARD.test = friendly_bard:TestStrategy
+  friendly.bard.test = friendly_bard:TestStrategy
+  friendly_bard.test = friendly_bard:TestStrategy
+  friendly--bard.test = friendly_bard:TestStrategy
+  FrIeNdLy-._.-bArD.test = friendly_bard:TestStrategy
+oteapi.mapping =
+  7.8-_9.test = 7_8_9:TestStrategy
 """
 
     for entry_point in create_importlib_entry_points(invalid_entry_points):


### PR DESCRIPTION
# Description:
<!-- Summary of change, including the issue to be addressed. -->
Fixes #361 

Use the PEP 508 regex for valid non-normalized package names in the `ENTRY_POINT_NAME_REGEX` for the `EntryPointStrategy` class.

It has been adapted, to fit in the context.

For more information, see: https://peps.python.org/pep-0508/#names.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
