### PR TITLE
Use `branch_name_extension` and auto-merge dependency PRs

### DIFF
--- a/.github/workflows/cd_release.yml
+++ b/.github/workflows/cd_release.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   publish:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/cd_release.yml@v2.5.2
+    uses: SINTEF/ci-cd/.github/workflows/cd_release.yml@v2.5.3
     if: github.repository == 'EMMC-ASBL/oteapi-core' && startsWith(github.ref, 'refs/tags/v')
     with:
       # General

--- a/.github/workflows/ci_automerge_dependabot.yml
+++ b/.github/workflows/ci_automerge_dependabot.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   update-dependabot-branch:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/ci_automerge_prs.yml@v2.5.2
+    uses: SINTEF/ci-cd/.github/workflows/ci_automerge_prs.yml@v2.5.3
     if: github.repository_owner == 'EMMC-ASBL' && startsWith(github.event.pull_request.head.ref, 'dependabot/') && github.actor == 'dependabot[bot]'
     secrets:
       PAT: ${{ secrets.RELEASE_PAT }}

--- a/.github/workflows/ci_automerge_dependabot.yml
+++ b/.github/workflows/ci_automerge_dependabot.yml
@@ -2,12 +2,12 @@ name: CI - Activate auto-merging for Dependabot PRs
 
 on:
   pull_request_target:
-    branches: [ci/dependabot-updates]
+    branches: [ci/dependabot-updates, release/pydantic-v1-support]
 
 jobs:
   update-dependabot-branch:
     name: External
     uses: SINTEF/ci-cd/.github/workflows/ci_automerge_prs.yml@v2.5.3
-    if: github.repository_owner == 'EMMC-ASBL' && startsWith(github.event.pull_request.head.ref, 'dependabot/') && github.actor == 'dependabot[bot]'
+    if: github.repository_owner == 'EMMC-ASBL' && ( ( startsWith(github.event.pull_request.head.ref, 'dependabot/') && github.actor == 'dependabot[bot]' ) || ( startsWith(github.event.pull_request.head.ref, 'ci/update-pyproject') && github.actor == 'TEAM4-0' ) )
     secrets:
       PAT: ${{ secrets.RELEASE_PAT }}

--- a/.github/workflows/ci_cd_updated_master.yml
+++ b/.github/workflows/ci_cd_updated_master.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   updates-to-master:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/ci_cd_updated_default_branch.yml@v2.5.2
+    uses: SINTEF/ci-cd/.github/workflows/ci_cd_updated_default_branch.yml@v2.5.3
     if: github.repository_owner == 'EMMC-ASBL'
     with:
       # General

--- a/.github/workflows/ci_check_dependencies.yml
+++ b/.github/workflows/ci_check_dependencies.yml
@@ -34,7 +34,7 @@ on:
 jobs:
   check-dependencies:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/ci_check_pyproject_dependencies.yml@v2.5.2
+    uses: SINTEF/ci-cd/.github/workflows/ci_check_pyproject_dependencies.yml@v2.5.3
     # Job Execution Criteria:
     # - It must be executed within the "origin" repository (EMMC-ASBL).
     # - Always run for scheduled events.
@@ -64,7 +64,7 @@ jobs:
 
   check-dependencies-release_pydantic-v1-support:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/ci_check_pyproject_dependencies.yml@v2.5.2
+    uses: SINTEF/ci-cd/.github/workflows/ci_check_pyproject_dependencies.yml@v2.5.3
     # Job Execution Criteria:
     # - It must be executed within the "origin" repository (EMMC-ASBL).
     # - Always run for scheduled events.

--- a/.github/workflows/ci_check_dependencies.yml
+++ b/.github/workflows/ci_check_dependencies.yml
@@ -63,7 +63,7 @@ jobs:
       PAT: ${{ secrets.RELEASE_PAT }}
 
   check-dependencies-release_pydantic-v1-support:
-    name: External
+    name: External (pydantic v1 support)
     uses: SINTEF/ci-cd/.github/workflows/ci_check_pyproject_dependencies.yml@v2.5.3
     # Job Execution Criteria:
     # - It must be executed within the "origin" repository (EMMC-ASBL).
@@ -89,5 +89,6 @@ jobs:
         dependency-name=pydantic...versions=>=2
         dependency-name=requests...versions=>=3
         dependency-name=urllib3
+      branch_name_extension: "release/pydantic-v1-support"
     secrets:
       PAT: ${{ secrets.RELEASE_PAT }}

--- a/.github/workflows/ci_dependabot.yml
+++ b/.github/workflows/ci_dependabot.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   create-collected-pr:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/ci_update_dependencies.yml@v2.5.2
+    uses: SINTEF/ci-cd/.github/workflows/ci_update_dependencies.yml@v2.5.3
     if: github.repository_owner == 'EMMC-ASBL'
     with:
       # General

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   basic_tests:
     name: External
-    uses: SINTEF/ci-cd/.github/workflows/ci_tests.yml@v2.5.2
+    uses: SINTEF/ci-cd/.github/workflows/ci_tests.yml@v2.5.3
     with:
       # pre-commit
       run_pre-commit: true


### PR DESCRIPTION
# Description:
<!-- Summary of change, including the issue to be addressed. -->
Fixes #365 by bumping to SINTEF/ci-cd v2.5.3 and also using the `branch_name_extension` input in the CI - Check dependencies workflow for the PR targeting the `release/pydantic-v1-support` branch.

Furthermore, we add the created PRs from the CI - Check dependencies workflow to be auto-merged (if all CI checks succeed), plus all @dependabot PRs (as well as the PR from the CI - Check dependencies branch) will be auto-merged into the `release/pydantic-v1-support` branch if they succeed the other CI checks.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
