### PR TITLE
Add branch name extension for CI workflow

### DIFF
--- a/.github/workflows/ci_check_dependencies.yml
+++ b/.github/workflows/ci_check_dependencies.yml
@@ -18,6 +18,7 @@
 name: CI - Check dependencies
 
 on:
+  push:
   schedule:
     - cron: "30 5 * * 1"
   workflow_dispatch:

--- a/.github/workflows/ci_check_dependencies.yml
+++ b/.github/workflows/ci_check_dependencies.yml
@@ -40,7 +40,7 @@ jobs:
     # - It must be executed within the "origin" repository (EMMC-ASBL).
     # - Always run for scheduled events.
     # - For manual triggers, it runs only if "target_branch" is "ci/dependabot-updates".
-    if: github.repository_owner == 'EMMC-ASBL' && ( github.event_name == 'schedule' || inputs.target_branch == 'ci/dependabot-updates' )
+    if: github.repository_owner == 'EMMC-ASBL' && ( github.event_name == 'push' || inputs.target_branch == 'ci/dependabot-updates' )
     with:
       git_username: "TEAM 4.0[bot]"
       git_email: "Team4.0@SINTEF.no"
@@ -71,7 +71,7 @@ jobs:
     # - It must be executed within the "origin" repository (EMMC-ASBL).
     # - Always run for scheduled events.
     # - For manual triggers, it runs only if "target_branch" is "release/pydantic-v1-support".
-    if: github.repository_owner == 'EMMC-ASBL' && ( github.event_name == 'schedule' || inputs.target_branch == 'release/pydantic-v1-support' )
+    if: github.repository_owner == 'EMMC-ASBL' && ( github.event_name == 'push' || inputs.target_branch == 'release/pydantic-v1-support' )
     with:
       git_username: "TEAM 4.0[bot]"
       git_email: "Team4.0@SINTEF.no"

--- a/.github/workflows/ci_check_dependencies.yml
+++ b/.github/workflows/ci_check_dependencies.yml
@@ -34,7 +34,7 @@ on:
 
 jobs:
   check-dependencies:
-    name: External
+    name: master
     uses: SINTEF/ci-cd/.github/workflows/ci_check_pyproject_dependencies.yml@v2.5.3
     # Job Execution Criteria:
     # - It must be executed within the "origin" repository (EMMC-ASBL).
@@ -65,7 +65,7 @@ jobs:
       PAT: ${{ secrets.RELEASE_PAT }}
 
   check-dependencies-release_pydantic-v1-support:
-    name: External (pydantic v1 support)
+    name: release/pydantic-v1-support
     uses: SINTEF/ci-cd/.github/workflows/ci_check_pyproject_dependencies.yml@v2.5.3
     # Job Execution Criteria:
     # - It must be executed within the "origin" repository (EMMC-ASBL).

--- a/.github/workflows/ci_check_dependencies.yml
+++ b/.github/workflows/ci_check_dependencies.yml
@@ -40,7 +40,7 @@ jobs:
     # - It must be executed within the "origin" repository (EMMC-ASBL).
     # - Always run for scheduled events.
     # - For manual triggers, it runs only if "target_branch" is "ci/dependabot-updates".
-    if: github.repository_owner == 'EMMC-ASBL' && ( github.event_name == 'push' || inputs.target_branch == 'ci/dependabot-updates' )
+    if: github.repository_owner == 'EMMC-ASBL' && ( github.event_name == 'schedule' || inputs.target_branch == 'ci/dependabot-updates' )
     with:
       git_username: "TEAM 4.0[bot]"
       git_email: "Team4.0@SINTEF.no"
@@ -71,7 +71,7 @@ jobs:
     # - It must be executed within the "origin" repository (EMMC-ASBL).
     # - Always run for scheduled events.
     # - For manual triggers, it runs only if "target_branch" is "release/pydantic-v1-support".
-    if: github.repository_owner == 'EMMC-ASBL' && ( github.event_name == 'push' || inputs.target_branch == 'release/pydantic-v1-support' )
+    if: github.repository_owner == 'EMMC-ASBL' && ( github.event_name == 'schedule' || inputs.target_branch == 'release/pydantic-v1-support' )
     with:
       git_username: "TEAM 4.0[bot]"
       git_email: "Team4.0@SINTEF.no"

--- a/.github/workflows/ci_check_dependencies.yml
+++ b/.github/workflows/ci_check_dependencies.yml
@@ -59,6 +59,7 @@ jobs:
         dependency-name=pydantic...versions=>=3
         dependency-name=requests...versions=>=3
         dependency-name=urllib3
+      branch_name_extension: "master"
     secrets:
       PAT: ${{ secrets.RELEASE_PAT }}
 

--- a/.github/workflows/ci_check_dependencies.yml
+++ b/.github/workflows/ci_check_dependencies.yml
@@ -18,7 +18,6 @@
 name: CI - Check dependencies
 
 on:
-  push:
   schedule:
     - cron: "30 5 * * 1"
   workflow_dispatch:


### PR DESCRIPTION
# Description:
<!-- Summary of change, including the issue to be addressed. -->
Fixes #371 

Add branch name extension for CI - Check dependencies job that checks dependencies for the `master` development branch.

This has been (quickly) tested by setting the run condition to `push` - however, there were no reason to create a PR for the `master` development branch, so it's still unsure whether this truly fixes the issue. In order to check this, one would have to temporarily manipulate the workflow further, with the risk of unnecessarily pushing to branches in an unwanted way.
I prefer to instead merge this and check to see how the workflow operates in the future when there is reason to open PRs for both development branches.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
