### PR TITLE
Added additional descriptive fields to ResourceConfig

### DIFF
--- a/oteapi/models/genericconfig.py
+++ b/oteapi/models/genericconfig.py
@@ -238,6 +238,7 @@ class GenericConfig(BaseModel):
         "be given as key/value-pairs or set as attributes.",
     )
 
+    # Consider to rename to modelDescription
     description: str = Field(
         __doc__,
         description="A description of the configuration model.",

--- a/oteapi/models/resourceconfig.py
+++ b/oteapi/models/resourceconfig.py
@@ -1,6 +1,6 @@
 """Pydantic Resource Configuration Data Model."""
 
-from typing import Annotated, Optional
+from typing import Annotated, List, Optional
 
 from pydantic import Field, model_validator
 from pydantic.networks import Url, UrlConstraints
@@ -26,7 +26,8 @@ class ResourceConfig(GenericConfig, SecretConfig):
             "Definition: The URL of the downloadable file in a given format. E.g. CSV "
             "file or RDF file.\n\nUsage: `downloadURL` *SHOULD* be used for the URL at"
             " which this distribution is available directly, typically through a HTTPS"
-            " GET request or SFTP."
+            " GET request or SFTP.\n\n"
+            "Ref: cdat:downloadURL"
         ),
     )
     mediaType: Optional[str] = Field(
@@ -36,7 +37,8 @@ class ResourceConfig(GenericConfig, SecretConfig):
             "[[IANA-MEDIA-TYPES](https://www.w3.org/TR/vocab-dcat-2/#bib-iana-media-types)]"
             ".\n\nUsage: This property *SHOULD* be used when the media"
             " type of the distribution is defined in IANA "
-            "[[IANA-MEDIA-TYPES](https://www.w3.org/TR/vocab-dcat-2/#bib-iana-media-types)]."
+            "[[IANA-MEDIA-TYPES](https://www.w3.org/TR/vocab-dcat-2/#bib-iana-media-types)].\n\n"
+            "Ref: dcat:mediaType"
         ),
     )
     accessUrl: Optional[HostlessAnyUrl] = Field(
@@ -47,30 +49,89 @@ class ResourceConfig(GenericConfig, SecretConfig):
             "`accessURL` *SHOULD* be used for the URL of a service or location that "
             "can provide access to this distribution, typically through a Web form, "
             "query or API call.\n`downloadURL` is preferred for direct links to "
-            "downloadable resources."
+            "downloadable resources.\n\n"
+            "Ref: dcat:accessURL"
         ),
     )
     accessService: Optional[str] = Field(
         None,
         description=(
-            "A data service that gives access to the distribution of the dataset."
+            "A data service that gives access to the distribution of the "
+            "dataset.\n\n"
+            "Usage: SHOULD be used to link to a description of a "
+            "dcat:DataService that can provide access to this distribution.\n\n"
+            "Ref: dcat:accessService"
         ),
     )
     license: Optional[str] = Field(
         None,
         description=(
-            "A legal document under which the distribution is made available."
+            "A legal document under which the distribution is made "
+            "available.\n\n"
+            "Usage: Information about licenses and rights MAY be provided "
+            "for the Resource. See also guidance at [9. License and rights "
+            "statements](https://www.w3.org/TR/vocab-dcat-3/#license-rights)."
+            "\n\nRef: dcterms:license"
         ),
     )
     accessRights: Optional[str] = Field(
         None,
         description=(
-            "A rights statement that concerns how the distribution is accessed."
+            "Information about who can access the resource or an indication "
+            "of its security status.\n\n"
+            "Usage: Information about licenses and rights MAY be provided "
+            "for the Resource. See also guidance at [9. License and rights "
+            "statements](https://www.w3.org/TR/vocab-dcat-3/#license-rights)."
+            "\n\nRef:dcterms:accessRights"
         ),
     )
     publisher: Optional[str] = Field(
         None,
-        description="The entity responsible for making the resource/item available.",
+        description=(
+            "The entity responsible for making the resource/item "
+            "available.\n\n"
+            "Usage: Resources of type "
+            "[foaf:Agent](http://xmlns.com/foaf/0.1/Agent) are recommended as "
+            "values for this property.\n\n"
+            "Ref: dcterms:publisher"
+        ),
+    )
+    title: Optional[str] = Field(
+        None,
+        description="A name given to the resource.\n\nRef: dcterms:title",
+    )
+    #
+    # For now `description` is commented out to avoid name conflice
+    # `GenericConfig.description`. Consider to rename
+    # `GenericConfig.description` to `GenericConfig.modelDescription`.
+    #
+    # description: Optional[str] = Field(
+    #     None,
+    #     description=(
+    #         "A free-text account of the resource.\n\nRef: dcterms:description"
+    #     ),
+    # )
+    keyword: Optional[List[str]] = Field(
+        None,
+        description=(
+            "A keyword or tag describing the resource.\n\n"
+            "Note: Keywords are useful for making the resource easier "
+            "searchable.\n\n"
+            "Ref: dcat:keyword"
+        ),
+    )
+    conformsTo: Optional[str] = Field(
+        None,
+        description=(
+            "An established standard to which the distribution "
+            "conforms.\n\n"
+            "Usage: This property SHOULD be used to indicate the model, "
+            "schema, ontology, view or profile that this representation "
+            "of a dataset conforms to.\n"
+            "This is (generally) a complementary concern to the media-type "
+            "or format.\n\n"
+            "Ref: dcterms:conformsTo"
+        ),
     )
 
     @model_validator(mode="after")


### PR DESCRIPTION
# Description
Added more descriptive fields to ResourceConfig to better support data documentation and improving findability and reusability of resources documented with OTEAPI.

Unfortunately could `description` not be added due to name conflict with the `description` field in `GenericConfig`. See issue #426.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [x] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
