### PR TITLE
Ensure config models are dumped safely

### DIFF
--- a/oteapi/plugins/factories.py
+++ b/oteapi/plugins/factories.py
@@ -85,7 +85,7 @@ class StrategyFactory:
             config_model = strategy_type.config_cls(**config)
         elif isinstance(config, get_args(StrategyConfig)):
             config_model = config
-            config = config.model_dump()
+            config = config.model_dump(mode="json", exclude_unset=True)
         else:
             raise TypeError("config should be either of type StrategyConfig or a dict.")
 


### PR DESCRIPTION
# Description:
<!-- Summary of change, including the issue to be addressed. -->
When creating a new strategy, if the given configuration is a pydantic model it is dumped/serialized as a Python dict before it is provided to the strategy upon initialization.
To ensure only the _actually_ provided configuration entries are passed on `exclude_unset=True` should be set. And furthermore, to ensure all values are valid JSON - something it should indeed already be if used through OTEAPI Services - the dump mode has been set to `"json"`. This will essentially ensure all values and nested values in the dumped model are valid JSON types.

This is related to EMMC-ASBL/otelib#178 and EMMC-ASBL/otelib#174.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
