### PR TITLE
Expect `EntryPoints` from `importlib.metadata`

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -7,6 +7,9 @@ on:
       - 'master'
       - 'push-action/**'  # Allow pushing to protected branches (using CasperWA/push-protected)
 
+env:
+  PYTEST_ADDOPTS: --color=yes
+
 jobs:
   basic_tests:
     name: External

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -74,7 +74,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     services:
       redis:
@@ -107,8 +107,8 @@ jobs:
 
     - name: Test with pytest
       run: |
-        pytest -vvv --cov-report=xml --cov=oteapi --durations=10
-        pytest --cov-report=xml:strategies.xml --cov=oteapi/strategies --durations=10
+        pytest -vvv --cov-report=xml --cov=oteapi
+        pytest --cov-report=xml:strategies.xml --cov=oteapi/strategies
 
     - name: Upload coverage to Codecov
       if: matrix.python-version == '3.9' && github.repository == 'EMMC-ASBL/oteapi-core'
@@ -133,7 +133,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4

--- a/oteapi/models/genericconfig.py
+++ b/oteapi/models/genericconfig.py
@@ -98,8 +98,12 @@ class AttrDict(BaseModel, MutableMapping):
                 self.model_fields_set.remove(key)
 
     def clear(self) -> None:
-        for field in self.model_dump():
-            del self[field]
+        # Ignore the deprecation warning from `__delitem__`
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+
+            for field in self.model_dump():
+                del self[field]
 
     def update(  # type: ignore[override]
         self,
@@ -138,7 +142,11 @@ class AttrDict(BaseModel, MutableMapping):
         if value == PydanticUndefined:
             raise KeyError(key)
         if key in self:
-            del self[key]
+            # Ignore the deprecation warning from `__delitem__`
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore", DeprecationWarning)
+
+                del self[key]
         return value
 
     def popitem(self) -> "Tuple[str, Any]":

--- a/oteapi/plugins/entry_points.py
+++ b/oteapi/plugins/entry_points.py
@@ -12,10 +12,16 @@ This therefore implements lazy loading of all plugin strategies.
 
 import importlib
 import re
+import sys
 from collections import abc
 from enum import Enum
-from importlib.metadata import entry_points as get_entry_points
 from typing import TYPE_CHECKING
+
+if sys.version_info < (3, 10):
+    from importlib_metadata import entry_points as get_entry_points
+else:
+    from importlib.metadata import entry_points as get_entry_points
+
 
 from oteapi.models import (
     FilterConfig,
@@ -545,7 +551,7 @@ def get_strategy_entry_points(
 
     collection = EntryPointStrategyCollection()
     oteapi_entry_points = sorted(
-        set(get_entry_points().get(f"oteapi.{strategy_type.value}", []))
+        set(get_entry_points(group=f"oteapi.{strategy_type.value}"))
     )
 
     if enforce_uniqueness:

--- a/oteapi/plugins/entry_points.py
+++ b/oteapi/plugins/entry_points.py
@@ -34,8 +34,12 @@ from oteapi.models import (
 
 if TYPE_CHECKING:  # pragma: no cover
     from collections.abc import Iterator
-    from importlib.metadata import EntryPoint
     from typing import Any, Dict, Optional, Set, Tuple, Type, Union
+
+    if sys.version_info < (3, 10):
+        from importlib_metadata import EntryPoint
+    else:
+        from importlib.metadata import EntryPoint
 
     from oteapi.interfaces import IStrategy
     from oteapi.models import StrategyConfig

--- a/oteapi/strategies/parse/image.py
+++ b/oteapi/strategies/parse/image.py
@@ -171,8 +171,10 @@ class ImageDataParseStrategy:
         cache = DataCache(config.datacache_config)
 
         # Treat image according to filter values
-        with cache.getfile(cache_key, suffix=mime_format) as filename:
-            image = Image.open(filename, formats=[image_format])
+        with (
+            cache.getfile(cache_key, suffix=mime_format) as filename,
+            Image.open(filename, formats=[image_format]) as image,
+        ):
             if config.crop:
                 image = image.crop(config.crop)
             if config.image_mode:
@@ -213,8 +215,5 @@ class ImageDataParseStrategy:
                 image_palette_key=image_palette_key,
                 image_info=image_info,
             )
-
-            # Explicitly close the image to avoid crashes on Windows
-            image.close()
 
         return content

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -131,7 +131,8 @@ filterwarnings = [
     # Treat all warnings as errors
     "error",
 
-
-    # "ignore:.*imp module.*:DeprecationWarning",
-    # "ignore:.*_yaml extension module.*:DeprecationWarning"
+    # Ignore UserWarning from pysftp concerning known_hosts
+    # This is usually only a problem in testing environments,
+    # but we don't want to fail the tests locally if a known_hosts file is missing
+    "ignore:.*Failed to load HostKeys.*:UserWarning",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,10 +14,12 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: MIT License",
 ]
 keywords = ["OTE", "OTE-API"]
-requires-python = ">=3.9"
+requires-python = ">=3.9,<3.13"
 dynamic = ["version"]
 
 dependencies = [
@@ -116,14 +118,19 @@ python_version = "3.9"
 ignore_missing_imports = true
 scripts_are_modules = true
 warn_unused_configs = true
-show_error_codes = true
+hide_error_codes = false
 allow_redefinition = true
+check_untyped_defs = true
 plugins = ["pydantic.mypy"]
 
 [tool.pytest.ini_options]
-minversion = "7.0"
-addopts = "-rs --cov-report=term"
+minversion = "8.2"
+addopts = "-rs --cov-report=term-missing:skip-covered --no-cov-on-fail"
 filterwarnings = [
-    "ignore:.*imp module.*:DeprecationWarning",
-    "ignore:.*_yaml extension module.*:DeprecationWarning"
+    # Treat all warnings as errors
+    "error",
+
+
+    # "ignore:.*imp module.*:DeprecationWarning",
+    # "ignore:.*_yaml extension module.*:DeprecationWarning"
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     # Core dependencies
     "agraph-python>=102.0.0,<103",
     "diskcache>=5.6.3,<6",
+    "importlib_metadata; python_version < '3.10'",
     "pydantic~=2.7",
     "pydantic-settings~=2.3",
     "typing-extensions~=4.12; python_version < '3.10'",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,10 +7,15 @@ from typing import TYPE_CHECKING
 import pytest
 
 if TYPE_CHECKING:
+    import sys
     from collections.abc import Callable, Iterable
-    from importlib.metadata import EntryPoint
     from pathlib import Path
     from typing import Any
+
+    if sys.version_info < (3, 10):
+        from importlib_metadata import EntryPoint
+    else:
+        from importlib.metadata import EntryPoint
 
     MockEntryPoints = Callable[[Iterable[EntryPoint | dict[str, Any]]], None]
 
@@ -104,7 +109,12 @@ def create_importlib_entry_points() -> Callable[[str], tuple[EntryPoint, ...]]:
 
     """  # noqa: E501
     import re
-    from importlib.metadata import EntryPoint
+    import sys
+
+    if sys.version_info < (3, 10):
+        from importlib_metadata import EntryPoint
+    else:
+        from importlib.metadata import EntryPoint
 
     def _create_entry_points(entry_points: str) -> tuple[EntryPoint, ...]:
         """Create EntryPoint.

--- a/tests/models/test_genericconfig.py
+++ b/tests/models/test_genericconfig.py
@@ -113,6 +113,7 @@ def test_attribute_contains(generic_config: "CustomConfig") -> None:
     assert "float" in generic_config.configuration
 
 
+@pytest.mark.filterwarnings("")
 def test_attribute_del_item(generic_config: "CustomConfig") -> None:
     """Test configuration.__delitem__."""
     # "float" is not defined as a pydantic model field, i.e., it's not part of the
@@ -125,7 +126,11 @@ def test_attribute_del_item(generic_config: "CustomConfig") -> None:
     assert "float" in generic_config.configuration.model_fields_set
     assert "float" not in generic_config.configuration.model_json_schema()["properties"]
 
-    del generic_config.configuration["float"]
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"^Item deletion used to reset fields to their default values\. To keep using this functionality, use the `reset_field\(\)` method\.$",
+    ):
+        del generic_config.configuration["float"]
 
     assert "float" not in generic_config.configuration
     assert "float" not in generic_config.configuration.model_fields_set
@@ -141,7 +146,11 @@ def test_attribute_del_item(generic_config: "CustomConfig") -> None:
     assert "string" in generic_config.configuration.model_fields_set
     assert "string" in generic_config.configuration.model_json_schema()["properties"]
 
-    del generic_config.configuration["string"]
+    with pytest.warns(
+        DeprecationWarning,
+        match=r"^Item deletion used to reset fields to their default values\. To keep using this functionality, use the `reset_field\(\)` method\.$",
+    ):
+        del generic_config.configuration["string"]
 
     assert "string" not in generic_config.configuration
     assert "string" not in generic_config.configuration.model_fields_set
@@ -197,11 +206,12 @@ def test_attribute_del_item_fail(generic_config: "CustomConfig") -> None:
     """Ensure KeyError is raised if key does not exist in AttrDict."""
     non_existent_key = "non_existant_key"
     assert non_existent_key not in generic_config.configuration
-    with pytest.raises(KeyError):
+    with pytest.raises(KeyError), pytest.warns(DeprecationWarning):
         del generic_config.configuration[non_existent_key]
 
     # Required fields can also be deleted
-    del generic_config.configuration["required_string"]
+    with pytest.warns(DeprecationWarning):
+        del generic_config.configuration["required_string"]
 
 
 def test_attribute_ne(generic_config: "CustomConfig") -> None:

--- a/tests/plugins/conftest.py
+++ b/tests/plugins/conftest.py
@@ -18,7 +18,12 @@ if TYPE_CHECKING:
 @pytest.fixture
 def get_local_strategies() -> "Callable[[str], Tuple[EntryPoint, ...]]":
     """Retrieve all entry points for strategy type from oteapi-core."""
-    from importlib.metadata import entry_points
+    import sys
+
+    if sys.version_info < (3, 10):
+        from importlib_metadata import entry_points
+    else:
+        from importlib.metadata import entry_points
 
     from oteapi.plugins.entry_points import StrategyType
 
@@ -45,7 +50,7 @@ def get_local_strategies() -> "Callable[[str], Tuple[EntryPoint, ...]]":
 
         return tuple(
             _
-            for _ in entry_points()[f"oteapi.{strategy_type.value}"]
+            for _ in entry_points(group=f"oteapi.{strategy_type.value}")
             if _.name.startswith("oteapi.")
         )
 

--- a/tests/plugins/conftest.py
+++ b/tests/plugins/conftest.py
@@ -1,22 +1,29 @@
 """Pytest fixture for all `oteapi.plugins` tests."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 import pytest
 
 if TYPE_CHECKING:
+    import sys
     from collections.abc import Callable, Iterable
-    from importlib.metadata import EntryPoint
-    from typing import Any, Dict, Tuple, Type, Union
+    from typing import Any
+
+    if sys.version_info < (3, 10):
+        from importlib_metadata import EntryPoint
+    else:
+        from importlib.metadata import EntryPoint
 
     from oteapi.models import StrategyConfig
     from oteapi.plugins.entry_points import StrategyType
 
-    MockEntryPoints = Callable[[Iterable[Union[EntryPoint, Dict[str, Any]]]], None]
+    MockEntryPoints = Callable[[Iterable[EntryPoint | dict[str, Any]]], None]
 
 
 @pytest.fixture
-def get_local_strategies() -> "Callable[[str], Tuple[EntryPoint, ...]]":
+def get_local_strategies() -> Callable[[str], tuple[EntryPoint, ...]]:
     """Retrieve all entry points for strategy type from oteapi-core."""
     import sys
 
@@ -28,8 +35,8 @@ def get_local_strategies() -> "Callable[[str], Tuple[EntryPoint, ...]]":
     from oteapi.plugins.entry_points import StrategyType
 
     def _get_local_strategies(
-        strategy_type: "Union[StrategyType, str]",
-    ) -> "Tuple[EntryPoint, ...]":
+        strategy_type: StrategyType | str,
+    ) -> tuple[EntryPoint, ...]:
         """Get oteapi-core entry points from strategy type.
 
         Parameters:
@@ -59,8 +66,8 @@ def get_local_strategies() -> "Callable[[str], Tuple[EntryPoint, ...]]":
 
 @pytest.fixture
 def load_test_strategies(
-    create_importlib_entry_points: "Callable[[str], Tuple[EntryPoint, ...]]",
-    mock_importlib_entry_points: "MockEntryPoints",
+    create_importlib_entry_points: Callable[[str], tuple[EntryPoint, ...]],
+    mock_importlib_entry_points: MockEntryPoints,
 ) -> None:
     """Load all strategies under `tests/static/strategies/`."""
     setup_cfg = """\
@@ -89,9 +96,7 @@ oteapi.transformation =
 
 
 @pytest.fixture
-def get_strategy_config() -> (
-    "Callable[[Union[StrategyType, str]], Type[StrategyConfig]]"
-):
+def get_strategy_config() -> Callable[[StrategyType | str], type[StrategyConfig]]:
     """Get the strategy configuration model class."""
     from oteapi.models import (
         FilterConfig,
@@ -103,7 +108,7 @@ def get_strategy_config() -> (
     )
     from oteapi.plugins.entry_points import StrategyType
 
-    def _get_config(strategy: "Union[StrategyType, str]") -> "Type[StrategyConfig]":
+    def _get_config(strategy: StrategyType | str) -> type[StrategyConfig]:
         """Return a `StrategyConfig` class for the given `StrategyType`.
 
         Parameters:

--- a/tests/plugins/test_entry_points.py
+++ b/tests/plugins/test_entry_points.py
@@ -1,5 +1,7 @@
 """Test the `oteapi.plugins.entry_points` module generally."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 import pytest
@@ -7,13 +9,13 @@ import pytest
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
     from importlib.metadata import EntryPoint
-    from typing import Any, Dict, Tuple, Union
+    from typing import Any
 
-    MockEntryPoints = Callable[[Iterable[Union[EntryPoint, Dict[str, Any]]]], None]
+    MockEntryPoints = Callable[[Iterable[EntryPoint | dict[str, Any]]], None]
 
 
 def test_get_strategy_entry_points(
-    get_local_strategies: "Callable[[str], Tuple[EntryPoint, ...]]",
+    get_local_strategies: Callable[[str], tuple[EntryPoint, ...]],
 ) -> None:
     """Simple test for `get_strategy_entry_points()`."""
     from oteapi.plugins.entry_points import (
@@ -54,7 +56,7 @@ def test_incorrect_strategy_type() -> None:
 
 
 def test_enforce_uniqueness_duplicate_strategies(
-    mock_importlib_entry_points: "MockEntryPoints",
+    mock_importlib_entry_points: MockEntryPoints,
 ) -> None:
     """Ensure `enforce_uniqueness=True` in `get_strategy_entry_points` ensures
     `KeyError` is raised for duplicate strategies, and doesn't raise if `False`."""
@@ -162,7 +164,7 @@ def test_eval_custom_classes() -> None:
     "enforce_uniqueness", (True, False), ids=("uniqueness", "no uniqueness")
 )
 def test_duplicate_entry_points(
-    mock_importlib_entry_points: "MockEntryPoints",
+    mock_importlib_entry_points: MockEntryPoints,
     enforce_uniqueness: bool,
 ) -> None:
     """Ensure duplicate entry points does not result in an error.
@@ -191,7 +193,7 @@ def test_duplicate_entry_points(
         get_strategy_entry_points,
     )
 
-    assert len(get_entry_points().get(f"oteapi.{strategy_type}", [])) == 2 * len(
+    assert len(get_entry_points(group=f"oteapi.{strategy_type}") or []) == 2 * len(
         test_entry_points
     )
 

--- a/tests/plugins/test_entry_points.py
+++ b/tests/plugins/test_entry_points.py
@@ -7,9 +7,14 @@ from typing import TYPE_CHECKING
 import pytest
 
 if TYPE_CHECKING:
+    import sys
     from collections.abc import Callable, Iterable
-    from importlib.metadata import EntryPoint
     from typing import Any
+
+    if sys.version_info < (3, 10):
+        from importlib_metadata import EntryPoint
+    else:
+        from importlib.metadata import EntryPoint
 
     MockEntryPoints = Callable[[Iterable[EntryPoint | dict[str, Any]]], None]
 
@@ -126,7 +131,12 @@ def test_strategytype_methods() -> None:
 
 def test_eval_custom_classes() -> None:
     """Check the custom classes can be re-invoked using `eval(repr())`."""
-    from importlib.metadata import EntryPoint
+    import sys
+
+    if sys.version_info < (3, 10):
+        from importlib_metadata import EntryPoint
+    else:
+        from importlib.metadata import EntryPoint
 
     from oteapi.plugins.entry_points import (
         EntryPointStrategy,

--- a/tests/plugins/test_entry_points_entrypointstrategy.py
+++ b/tests/plugins/test_entry_points_entrypointstrategy.py
@@ -1,5 +1,7 @@
 """Test the `oteapi.plugins.entry_points` module's `EntryPointStrategy*` classes."""
 
+from __future__ import annotations
+
 from typing import TYPE_CHECKING
 
 import pytest
@@ -7,9 +9,9 @@ import pytest
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable
     from importlib.metadata import EntryPoint
-    from typing import Any, Dict, List, Tuple, Union
+    from typing import Any
 
-    MockEntryPoints = Callable[[Iterable[Union[EntryPoint, Dict[str, Any]]]], None]
+    MockEntryPoints = Callable[[Iterable[EntryPoint | dict[str, Any]]], None]
 
 
 def test_no_available_strategies(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -35,7 +37,7 @@ def test_no_available_strategies(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_entry_point_name_syntax(
-    create_importlib_entry_points: "Callable[[str], Tuple[EntryPoint, ...]]",
+    create_importlib_entry_points: Callable[[str], tuple[EntryPoint, ...]],
 ) -> None:
     """Test edge-case and invalid entry point names when initializing
     `EntryPointStrategy`s."""
@@ -91,7 +93,7 @@ oteapi.mapping =
 
 
 def test_collection_remove(
-    get_local_strategies: "Callable[[str], Tuple[EntryPoint, ...]]",
+    get_local_strategies: Callable[[str], tuple[EntryPoint, ...]],
 ) -> None:
     """Test `EntryPointStrategyCollection.remove()`."""
     from oteapi.plugins.entry_points import (
@@ -131,7 +133,7 @@ def test_collection_remove(
 
 
 def test_collection_contains(
-    create_importlib_entry_points: "Callable[[str], Tuple[EntryPoint, ...]]",
+    create_importlib_entry_points: Callable[[str], tuple[EntryPoint, ...]],
 ) -> None:
     """Test `EntryPointStrategyCollection.__contains__()` /
     `x in EntryPointStrategyCollection()`."""
@@ -192,7 +194,7 @@ oteapi.parse =
 
 
 def test_invalid_module(
-    create_importlib_entry_points: "Callable[[str], Tuple[EntryPoint, ...]]",
+    create_importlib_entry_points: Callable[[str], tuple[EntryPoint, ...]],
 ) -> None:
     """Ensure `EntryPointNotFound` is raised if a module cannot be imported."""
     from importlib import import_module
@@ -235,7 +237,7 @@ oteapi.download =
 
 
 def test_sorting_priority(
-    create_importlib_entry_points: "Callable[[str], Tuple[EntryPoint, ...]]",
+    create_importlib_entry_points: Callable[[str], tuple[EntryPoint, ...]],
 ) -> None:
     """Ensure `EntryPointStrategy`s are sorted correctly according to the intended
     priority order in `__lt__()`."""
@@ -266,7 +268,7 @@ oteapi.parse =
     }
     collection = EntryPointStrategyCollection()
     collection.exclusive_add(*entry_point_strategies)
-    sorted_collection: "List[EntryPointStrategy]" = sorted(collection)
+    sorted_collection: list[EntryPointStrategy] = sorted(collection)
     assert sorted_collection == sorted(entry_point_strategies)
     for index, strategy in enumerate(expected_sorting):
         assert sorted_collection[index].strategy == strategy
@@ -279,7 +281,7 @@ oteapi.parse =
 
 
 def test_collection_getitem(
-    create_importlib_entry_points: "Callable[[str], Tuple[EntryPoint, ...]]",
+    create_importlib_entry_points: Callable[[str], tuple[EntryPoint, ...]],
 ) -> None:
     """Test `EntryPointStrategyCollection.__getitem__()` /
     `EntryPointStrategyCollection()[x]`."""
@@ -348,7 +350,7 @@ oteapi.parse =
 
 
 def test_collection_eq(
-    create_importlib_entry_points: "Callable[[str], Tuple[EntryPoint, ...]]",
+    create_importlib_entry_points: Callable[[str], tuple[EntryPoint, ...]],
 ) -> None:
     """Test `EntryPointStrategyCollection.__eq__()` /
     `EntryPointStrategyCollection() == EntryPointStrategyCollection()`."""
@@ -378,7 +380,7 @@ oteapi.download =
 
 
 def test_collection_str_repr(
-    create_importlib_entry_points: "Callable[[str], Tuple[EntryPoint, ...]]",
+    create_importlib_entry_points: Callable[[str], tuple[EntryPoint, ...]],
 ) -> None:
     """Test `EntryPointStrategyCollection.__str__()` and `.__repr__()` /
     `str(EntryPointStrategyCollection())` or `repr()`."""
@@ -413,7 +415,7 @@ oteapi.parse =
 
 
 def test_strategy_eq(
-    create_importlib_entry_points: "Callable[[str], Tuple[EntryPoint, ...]]",
+    create_importlib_entry_points: Callable[[str], tuple[EntryPoint, ...]],
 ) -> None:
     """Test `EntryPointStrategy.__eq__()` /
     `EntryPointStrategy() == EntryPointStrategy()`."""

--- a/tests/plugins/test_entry_points_entrypointstrategy.py
+++ b/tests/plugins/test_entry_points_entrypointstrategy.py
@@ -7,9 +7,14 @@ from typing import TYPE_CHECKING
 import pytest
 
 if TYPE_CHECKING:
+    import sys
     from collections.abc import Callable, Iterable
-    from importlib.metadata import EntryPoint
     from typing import Any
+
+    if sys.version_info < (3, 10):
+        from importlib_metadata import EntryPoint
+    else:
+        from importlib.metadata import EntryPoint
 
     MockEntryPoints = Callable[[Iterable[EntryPoint | dict[str, Any]]], None]
 

--- a/tests/plugins/test_factories.py
+++ b/tests/plugins/test_factories.py
@@ -5,9 +5,14 @@ from typing import TYPE_CHECKING
 import pytest
 
 if TYPE_CHECKING:
+    import sys
     from collections.abc import Callable, Iterable
-    from importlib.metadata import EntryPoint
     from typing import Any, Dict, Type, Union
+
+    if sys.version_info < (3, 10):
+        from importlib_metadata import EntryPoint
+    else:
+        from importlib.metadata import EntryPoint
 
     from oteapi.models import StrategyConfig
     from oteapi.plugins.entry_points import StrategyType

--- a/tests/plugins/test_factories.py
+++ b/tests/plugins/test_factories.py
@@ -52,7 +52,10 @@ def test_load_strategies(mock_importlib_entry_points: "MockEntryPoints") -> None
     assert StrategyFactory.strategy_create_func[
         StrategyType(strategy_type)
     ] == EntryPointStrategyCollection(
-        *(EntryPointStrategy(_) for _ in get_entry_points()[f"oteapi.{strategy_type}"])
+        *(
+            EntryPointStrategy(_)
+            for _ in get_entry_points(group=f"oteapi.{strategy_type}")
+        )
     )
     for key in StrategyFactory.strategy_create_func:
         if key != StrategyType(strategy_type):

--- a/tests/strategies/parse/test_image.py
+++ b/tests/strategies/parse/test_image.py
@@ -145,9 +145,9 @@ def test_image(
             assert data.shape == (cropped_size if mode == "P" else (*cropped_size, 3))
 
     if filename_cropped and image_format in ("png", "gif", "eps", "tiff"):
-        cropped = Image.open(reference_file, formats=[image_format])
-        arr = np.asarray(cropped)
-        assert np.all(data == arr)
+        with Image.open(reference_file, formats=[image_format]) as cropped:
+            arr = np.asarray(cropped)
+            assert np.all(data == arr)
 
 
 @pytest.mark.parametrize("crop", [None, (100, 50, 450, 300)], ids=["no crop", "crop"])

--- a/tests/strategies/transformation/test_celery_remote.py
+++ b/tests/strategies/transformation/test_celery_remote.py
@@ -19,7 +19,6 @@ def skip_if_no_docker_or_windows() -> None:
     is_windows = platform.system() == "Windows"
 
     if is_windows or not docker_exists:
-        print("Skip!")
         pytest.skip("Docker is not available or using Windows!")
 
 


### PR DESCRIPTION
# Description:
<!-- Summary of change, including the issue to be addressed. -->
Closes #395 

To support older Python versions the [`importlib_metadata`](https://importlib-metadata.readthedocs.io/) package is installed for Python < 3.10.
Otherwise, it is now expected that [`importlib.metadata.entry_points()`](https://docs.python.org/3.12/library/importlib.metadata.html#entry-points) returns `importlib.metadata.EntryPoints`, not a `dict`.

Furthermore, the pytest and mypy configuration is updated.
For pytest all warnings are now considered errors (this is helpful to catch "new" deprecation warnings in dependencies.
This has also resulted in a few minor test fixes, where warnings were issued, and one where it was due to a file not being properly closed - very good :)

CI testing has been extended to include Python 3.11 and 3.12.
Furthermore, the metadata for the package has been extended to include these versions.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
