### PR TITLE
Extend inputs for http/https download strategy

### DIFF
--- a/oteapi/strategies/download/https.py
+++ b/oteapi/strategies/download/https.py
@@ -142,6 +142,8 @@ class HTTPSStrategy:
                 headers=self.download_config.configuration.headers,
                 cookies=self.download_config.configuration.cookies,
                 params=self.download_config.configuration.query_parameters,
+                # No reason to check the method is correct for sending content (POST),
+                # since this is validated in the config model.
                 data=self.download_config.configuration.post_body,
                 json=self.download_config.configuration.post_body_json,
             )

--- a/oteapi/strategies/download/https.py
+++ b/oteapi/strategies/download/https.py
@@ -2,10 +2,17 @@
 
 from __future__ import annotations
 
-from typing import Optional
+import sys
+import warnings
+from typing import Any, Optional, Union
+
+if sys.version_info >= (3, 9, 1):
+    from typing import Literal
+else:
+    from typing_extensions import Literal  # type: ignore[assignment]
 
 import requests
-from pydantic import AnyHttpUrl, Field
+from pydantic import AnyHttpUrl, Field, field_validator, model_validator
 from pydantic.dataclasses import dataclass
 
 from oteapi.datacache import DataCache
@@ -22,6 +29,69 @@ class HTTPSConfig(AttrDict):
             "content."
         ),
     )
+
+    http_method: Literal["GET", "POST"] = Field(
+        "GET",
+        description=(
+            "HTTP method to use for the download request. Only GET and POST are "
+            "supported."
+        ),
+    )
+
+    headers: Optional[dict[str, str]] = Field(
+        None,
+        description="HTTP headers to be included in the download request.",
+    )
+
+    cookies: Optional[dict[str, str]] = Field(
+        None,
+        description="Cookies to be included in the download request.",
+    )
+
+    query_parameters: Optional[dict[str, Union[str, list[str]]]] = Field(
+        None,
+        description=(
+            "Query parameters to be included in the download request. Note, these can "
+            "be included directly in the `downloadURL` as well."
+        ),
+    )
+
+    post_body: Optional[Union[dict[str, Any], list[tuple[str, Any]], bytes]] = Field(
+        None,
+        description=(
+            "The body of the POST request. This can be a a dictionary, list of tuples "
+            "or bytes. This field is mutually exclusive with `post_body_json`."
+        ),
+    )
+
+    post_body_json: Optional[Any] = Field(
+        None,
+        description=(
+            "The body of the POST request as a JSON serializable Python object. This "
+            "will be serialized to JSON and sent as the body of the POST request. "
+            "This field is mutually exclusive with `post_body`."
+        ),
+    )
+
+    @field_validator("http_method", mode="before")
+    @classmethod
+    def _upper_case_http_method(cls, value: Any) -> Any:
+        if isinstance(value, str):
+            return value.upper()
+        return value
+
+    @model_validator(mode="after")
+    def _validate_post_bodies(self) -> HTTPSConfig:
+        if self.http_method == "GET" and (self.post_body or self.post_body_json):
+            warnings.warn(
+                "POST body is provided for a GET requests - it will be ignored.",
+                stacklevel=2,
+            )
+        if self.post_body and self.post_body_json:
+            raise ValueError(
+                "Only one of post_body and post_body_json can be provided."
+            )
+        return self
 
 
 class HTTPSResourceConfig(ResourceConfig):
@@ -64,10 +134,16 @@ class HTTPSStrategy:
         if cache.config.accessKey and cache.config.accessKey in cache:
             key = cache.config.accessKey
         else:
-            req = requests.get(
-                str(self.download_config.downloadUrl),
+            req = requests.request(
+                method=self.download_config.configuration.http_method,
+                url=str(self.download_config.downloadUrl),
                 allow_redirects=True,
                 timeout=(3, 27),  # timeout: (connect, read) in seconds
+                headers=self.download_config.configuration.headers,
+                cookies=self.download_config.configuration.cookies,
+                params=self.download_config.configuration.query_parameters,
+                data=self.download_config.configuration.post_body,
+                json=self.download_config.configuration.post_body_json,
             )
             key = cache.add(req.content)
 

--- a/oteapi/strategies/download/https.py
+++ b/oteapi/strategies/download/https.py
@@ -87,6 +87,8 @@ class HTTPSConfig(AttrDict):
                 "POST body is provided for a GET requests - it will be ignored.",
                 stacklevel=2,
             )
+            self.post_body = None
+            self.post_body_json = None
         if self.post_body and self.post_body_json:
             raise ValueError(
                 "Only one of post_body and post_body_json can be provided."


### PR DESCRIPTION
# Description:

Adds these strategy configuration options for the http/https download strategy:
- headers
- cookies
- query_parameters
- post_body
- post_body_json
- method

The method reflects the HTTP method to use and defaults to `GET` - only `GET` and `POST` are allowed.

post_body and post_body_json are mutually exclusive and a warning will be emitted if either are defined while using the `GET` method (as they will be ignored).

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [x] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
