### PR TITLE
Fix pydantic.networks imports

### DIFF
--- a/oteapi/models/resourceconfig.py
+++ b/oteapi/models/resourceconfig.py
@@ -5,12 +5,12 @@ from __future__ import annotations
 from typing import Annotated, Optional
 
 from pydantic import Field, model_validator
-from pydantic.networks import Url, UrlConstraints
+from pydantic.networks import AnyUrl, UrlConstraints
 
 from oteapi.models.genericconfig import GenericConfig
 from oteapi.models.secretconfig import SecretConfig
 
-HostlessAnyUrl = Annotated[Url, UrlConstraints(host_required=False)]
+HostlessAnyUrl = Annotated[AnyUrl, UrlConstraints(host_required=False)]
 
 
 class ResourceConfig(GenericConfig, SecretConfig):

--- a/oteapi/strategies/download/sftp.py
+++ b/oteapi/strategies/download/sftp.py
@@ -9,12 +9,12 @@ from typing import Annotated, Optional
 import pysftp
 from pydantic import Field
 from pydantic.dataclasses import dataclass
-from pydantic.networks import Url, UrlConstraints
+from pydantic.networks import AnyUrl, UrlConstraints
 
 from oteapi.datacache import DataCache
 from oteapi.models import AttrDict, DataCacheConfig, ResourceConfig
 
-AnyFtpUrl = Annotated[Url, UrlConstraints(allowed_schemes=["ftp", "sftp"])]
+AnyFtpUrl = Annotated[AnyUrl, UrlConstraints(allowed_schemes=["ftp", "sftp"])]
 
 
 class SFTPConfig(AttrDict):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,17 +28,17 @@ dependencies = [
     "agraph-python>=102.0.0,<103",
     "diskcache>=5.6.3,<6",
     "importlib_metadata; python_version < '3.10'",
-    "pydantic~=2.8",
-    "pydantic-settings~=2.4",
+    "pydantic~=2.10",
+    "pydantic-settings~=2.6",
     "typing-extensions~=4.12; python_version < '3.10'",
 
     # Strategy dependencies
-    "celery>=5.3.5,<6",
-    "openpyxl>=3.1.2,<4",
-    "Pillow>=10.1.0,<12",
-    "psycopg[binary]~=3.2.1",
+    "celery>=5.4.0,<6",
+    "openpyxl>=3.1.5,<4",
+    "Pillow>=10.4.0,<12",
+    "psycopg[binary]~=3.2",
     "pysftp~=0.2.9",
-    "requests>=2.31.0,<3",
+    "requests>=2.32.0,<3",
 
     # Follow issue EMMC-ASBL/oteapi-services#328 for more information
     "urllib3<2",


### PR DESCRIPTION
# Description:
<!-- Summary of change, including the issue to be addressed. -->

## Copilot summary

This pull request includes updates to the `oteapi` project to improve compatibility and functionality by updating dependencies and modifying the usage of URL types in the codebase. The most important changes include updating the `pydantic` dependency, modifying URL types to `AnyUrl`, and updating other dependencies in `pyproject.toml`.

Dependency updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L31-R41): Updated `pydantic` to version `2.10` and `pydantic-settings` to version `2.6` to ensure compatibility with the latest features and bug fixes.
* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L31-R41): Updated other dependencies such as `celery`, `openpyxl`, `Pillow`, `psycopg`, and `requests` to their latest versions to maintain compatibility and improve performance.

Code updates:

* [`oteapi/models/resourceconfig.py`](diffhunk://#diff-b5bced848bd859b7045892b8a1782f86a80906e7533a48c3038bfe902de570f9L8-R13): Changed `Url` to `AnyUrl` for `HostlessAnyUrl` to support a wider range of URLs.
* [`oteapi/strategies/download/sftp.py`](diffhunk://#diff-e0594031149cfeb59474007b2cab8c0174bb6cbdda1a305c5f741ca23ddd5dabL12-R17): Changed `Url` to `AnyUrl` for `AnyFtpUrl` to support a wider range of FTP and SFTP URLs.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
