### PR TITLE
Avoid current pydantic v2.10 versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
     "agraph-python>=102.0.0,<103",
     "diskcache>=5.6.3,<6",
     "importlib_metadata; python_version < '3.10'",
-    "pydantic~=2.10",
+    "pydantic~=2.9,!=2.10.0,!=2.10.1",
     "pydantic-settings~=2.6",
     "typing-extensions~=4.12; python_version < '3.10'",
 


### PR DESCRIPTION
# Description:
<!-- Summary of change, including the issue to be addressed. -->
The current versions of pydantic v2.10 have several breaking changes to the `Url` classes.
This becomes clear in the [OTEAPI Services](https://github.com/EMMC-ASBL/oteapi-services) tests, using the currently latest version.

These changes have been tested locally with an OTEAPI Services test suite.

## Copilot summary

This pull request includes a small but important change to the `pyproject.toml` file. The change updates the version constraints for the `pydantic` dependency to avoid specific versions that may have issues.

Dependency updates:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L31-R31): Updated the `pydantic` dependency to `~=2.9,!=2.10.0,!=2.10.1` to exclude problematic versions 2.10.0 and 2.10.1.

## Type of change:
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer:
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
