### PR TITLE
Drop safety in favor of pip-audit

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -22,10 +22,8 @@ jobs:
       run_pre-commit: false
 
       # pylint & safety
-      python_version_pylint_safety: "3.10"
-
       run_pylint: false
-      run_safety: true
+      run_safety: false
 
       # Build package
       run_build_package: true
@@ -57,6 +55,28 @@ jobs:
         (oteapi/models/mappingconfig.py),[oteapi.models.mappingconfig.MappingConfig.mappingType]
         (oteapi/models/transformationconfig.py),[oteapi.models.transformationconfig.TransformationConfig.transformationType]
       warnings_as_errors: true
+
+  pip-audit:
+    name: pip-audit
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout ${{ github.repository }}
+      uses: actions/checkout@v4
+
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+
+    - name: Install Python dependencies
+      run: |
+        python -m pip install -U pip
+        pip install -U setuptools wheel
+        pip install -e .[dev]
+
+    - name: Run pip-audit
+      uses: pypa/gh-action-pip-audit@v1.1.0
 
   pytest-linux:
     name: pytest (linux-py${{ matrix.python-version }})


### PR DESCRIPTION
# Description
<!-- Summary of change, including the issue to be addressed. -->
Safety is deprecating `safety check` in favor of `safety scan`, which requires one to register a user with their platform.

[pip-audit](https://github.com/pypa/pip-audit) is a good alternative.

## AI Summary

This pull request updates the CI workflow configuration in `.github/workflows/ci_tests.yml` to adjust security auditing tools and add a new job for dependency vulnerability checks. The most important changes include disabling `safety` checks, introducing a new `pip-audit` job, and related updates.

### Security auditing updates:

* Disabled the `safety` tool by setting `run_safety` to `false` in the CI configuration. This change suggests a shift away from using `safety` for dependency vulnerability checks.
* Added a new `pip-audit` job to the CI workflow. This job uses the `pypa/gh-action-pip-audit` GitHub Action to perform dependency vulnerability audits. It includes steps to set up Python 3.10, install dependencies, and run the audit.

## Type of change
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
