### PR TITLE
Skip celery tests using docker for now

### DIFF
--- a/tests/strategies/transformation/test_celery_remote.py
+++ b/tests/strategies/transformation/test_celery_remote.py
@@ -24,7 +24,8 @@ def _skip_if_no_docker_or_windows() -> None:
         pytest.skip("Docker is not available or using Windows!")
 
 
-@pytest.mark.usefixtures("_skip_if_no_docker_or_windows")
+# @pytest.mark.usefixtures("_skip_if_no_docker_or_windows")
+@pytest.mark.skip("Requires fix for pytest-celery, see #613")
 def test_celery_remote(
     celery_setup: CeleryTestSetup,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
# Description
<!-- Summary of change, including the issue to be addressed. -->

This is supposed to be a temporary "fix" before the issue is fixed in `pytest-celery`. See #613 for more information.

This pull request modifies the test setup for `test_celery_remote` in `tests/strategies/transformation/test_celery_remote.py` to address a known issue with `pytest-celery`.

### Changes to test setup:

* The `@pytest.mark.usefixtures("_skip_if_no_docker_or_windows")` decorator was commented out and replaced with `@pytest.mark.skip("Requires fix for pytest-celery, see #613")` to temporarily skip the test due to an unresolved issue with `pytest-celery`.

## Type of change
<!-- Put an `x` in the box that applies. -->
- [ ] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
