### PR TITLE
Cap paramiko to below v4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     # Strategy dependencies
     "celery>=5.5.1,<6",
     "openpyxl>=3.1.5,<4",
+    "paramiko<4",
     "Pillow>=10.4.0,<12",
     "psycopg[binary]~=3.2.6",
     "pysftp~=0.2.9",


### PR DESCRIPTION
# Description

Capping paramiko should ensure the SFTP strategy still works as intended.

## AI Summary

This pull request introduces a new dependency to the project, expanding its capabilities for SSH and SFTP operations.

Dependency updates:

* Added `paramiko<4` to the `dependencies` list in `pyproject.toml` to enable SSH and SFTP support.

## Type of change
<!-- Put an `x` in the box that applies. -->
- [x] Bug fix.
- [ ] New feature.
- [ ] Documentation update.

## Checklist for the reviewer
<!-- Put an `x` in the boxes that apply. These can be filled by reviewer after the PR is created. -->

This checklist should be used as a help for the reviewer.

- [ ] Is the change limited to one issue?
- [ ] Does this PR close the issue?
- [ ] Is the code easy to read and understand?
- [ ] Do all new feature have an accompanying new test?
- [ ] Has the documentation been updated as necessary?
