### PR TITLE
Pin RabbitMQ broker image to 3.x in Celery tests

### DIFF
--- a/tests/strategies/transformation/conftest.py
+++ b/tests/strategies/transformation/conftest.py
@@ -1,0 +1,11 @@
+"""Pytest fixtures for transformation strategy tests."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def default_rabbitmq_broker_image() -> str:
+    """Pin RabbitMQ to 3.x to avoid RabbitMQ 4.x removing transient_nonexcl_queues."""
+    return "rabbitmq:3"


### PR DESCRIPTION
## Summary

Pin the RabbitMQ Docker image used by the `test_celery_remote` tests to `rabbitmq:3` instead of `rabbitmq:latest`.
RabbitMQ 4.x removed support for the `transient_nonexcl_queues` feature, which Celery/kombu requires during worker startup, causing all Linux CI jobs to fail.

## Motivation

Fixes #680

The `pytest-celery` library defaults to `rabbitmq:latest` for its broker container.
A recent promotion of RabbitMQ 4.x to that tag broke the `test_celery_remote` test on every Linux runner, blocking every incoming PR (e.g. #677).

## Changes

### `tests/strategies/transformation/conftest.py` (new file)

Override the `default_rabbitmq_broker_image` fixture — the extension point that `pytest-celery` explicitly exposes for this purpose — to return `"rabbitmq:3"`.
No other test behaviour changes.

## Test Plan

- [x] `pre-commit run -a` passes with no modifications
- [x] `test_celery_remote` passes on Linux runners (verified by CI on this PR)

---

Generated using AI.