### PR TITLE
Replace pysftp with paramiko, lift paramiko ceiling to <6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ data/**
 # Edit at https://www.toptal.com/developers/gitignore?templates=python,visualstudio,vscode,emacs
 
 .docker
+.claude/
 
 ### Emacs ###
 # -*- mode: gitignore; -*-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -95,6 +95,7 @@ repos:
     - id: mypy
       exclude: ^tests/.*$
       additional_dependencies:
+      - "types-paramiko"
       - "types-requests"
       - "pydantic>=2,<3"
 

--- a/oteapi/strategies/download/sftp.py
+++ b/oteapi/strategies/download/sftp.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 from typing import Annotated
 
-import pysftp
+import paramiko
 from pydantic import Field
 from pydantic.dataclasses import dataclass
 from pydantic.networks import AnyUrl, UrlConstraints
@@ -65,28 +65,31 @@ class SFTPStrategy:
 
     def get(self) -> SFTPContent:
         """Download via sftp"""
+        url = self.download_config.downloadUrl
+        if url.host is None or url.path is None:
+            raise ValueError(f"Invalid (S)FTP URL (missing host or path): {url!r}")
+
         cache = DataCache(self.download_config.configuration.datacache_config)
         if cache.config.accessKey and cache.config.accessKey in cache:
             key = cache.config.accessKey
         else:
-            # Setup connection options
-            cnopts = pysftp.CnOpts()
-            cnopts.hostkeys = None
-
-            # open connection and store data locally
-            with pysftp.Connection(
-                host=self.download_config.downloadUrl.host,
-                username=self.download_config.downloadUrl.username,
-                password=self.download_config.downloadUrl.password,
-                port=self.download_config.downloadUrl.port,
-                cnopts=cnopts,
-            ) as sftp:
+            with paramiko.SSHClient() as client:
+                client.set_missing_host_key_policy(
+                    paramiko.AutoAddPolicy()
+                )  # nosec B507
+                client.connect(
+                    hostname=url.host,
+                    username=url.username,
+                    password=url.password,
+                    port=url.port or 22,
+                )
                 # Because of insane locking on Windows, we have to close
                 # the downloaded file before adding it to the cache
                 with NamedTemporaryFile(prefix="oteapi-sftp-", delete=False) as handle:
                     localpath = Path(handle.name).resolve()
                 try:
-                    sftp.get(self.download_config.downloadUrl.path, localpath=localpath)
+                    with client.open_sftp() as sftp:
+                        sftp.get(url.path, str(localpath))
                     key = cache.add(localpath.read_bytes())
                 finally:
                     localpath.unlink()

--- a/oteapi/strategies/download/sftp.py
+++ b/oteapi/strategies/download/sftp.py
@@ -67,7 +67,10 @@ class SFTPStrategy:
         """Download via sftp"""
         url = self.download_config.downloadUrl
         if not url.host or not url.path:
-            raise ValueError(f"Invalid (S)FTP URL (missing host or path): {url!r}")
+            raise ValueError(
+                "Invalid (S)FTP URL (missing host or path): "
+                f"host={url.host!r}, path={url.path!r}"
+            )
 
         cache = DataCache(self.download_config.configuration.datacache_config)
         if cache.config.accessKey and cache.config.accessKey in cache:

--- a/oteapi/strategies/download/sftp.py
+++ b/oteapi/strategies/download/sftp.py
@@ -66,7 +66,7 @@ class SFTPStrategy:
     def get(self) -> SFTPContent:
         """Download via sftp"""
         url = self.download_config.downloadUrl
-        if url.host is None or url.path is None:
+        if not url.host or not url.path:
             raise ValueError(f"Invalid (S)FTP URL (missing host or path): {url!r}")
 
         cache = DataCache(self.download_config.configuration.datacache_config)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     # Strategy dependencies
     "celery>=5.6.0,<6",
     "openpyxl>=3.1.5,<4",
-    "paramiko<6",
+    "paramiko>=4,<6",
     "Pillow>=10.4.0,<13",
     "psycopg[binary]>=3.2.6,<4",
     "requests>=2.32.3,<3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,10 +31,9 @@ dependencies = [
     # Strategy dependencies
     "celery>=5.6.0,<6",
     "openpyxl>=3.1.5,<4",
-    "paramiko<4",  # version 4+ has some breaking changes and is not yet supported by pysftp
+    "paramiko<6",
     "Pillow>=10.4.0,<13",
     "psycopg[binary]>=3.2.6,<4",
-    "pysftp~=0.2.9",
     "requests>=2.32.3,<3",
 ]
 
@@ -129,11 +128,6 @@ addopts = "-rs --cov-report=term-missing:skip-covered --no-cov-on-fail"
 filterwarnings = [
     # Treat all warnings as errors
     "error",
-
-    # Ignore UserWarning from pysftp concerning known_hosts
-    # This is usually only a problem in testing environments,
-    # but we don't want to fail the tests locally if a known_hosts file is missing
-    "ignore:.*Failed to load HostKeys.*:UserWarning",
 ]
 
 [tool.ruff.lint]

--- a/tests/strategies/download/test_sftp.py
+++ b/tests/strategies/download/test_sftp.py
@@ -10,11 +10,8 @@ if TYPE_CHECKING:
     import pytest
 
 
-class MockSFTPConnection:
-    """A mockup of pysftp.Connection, as used in SFTPStrategy.get()."""
-
-    def __init__(self, **kwargs) -> None:
-        """Dummy initializer passing through any kwargs."""
+class MockSFTPClient:
+    """A mockup of paramiko.SFTPClient, as used in SFTPStrategy.get()."""
 
     def __enter__(self):
         """Entry into context manager."""
@@ -23,8 +20,8 @@ class MockSFTPConnection:
     def __exit__(self, exc_type: object, exc_value: object, traceback: object) -> None:
         """Dummy exit from context manager."""
 
-    def get(self, remotepath: str, localpath: Path) -> None:
-        """A mockup of pysftp.Connection.get() as called in SFTPStrategy.get()."""
+    def get(self, remotepath: str, localpath: str) -> None:
+        """A mockup of SFTPClient.get() as called in SFTPStrategy.get()."""
         from pathlib import Path, PureWindowsPath
         from shutil import copyfile
 
@@ -35,15 +32,36 @@ class MockSFTPConnection:
         copyfile(remote_as_path, localpath)
 
 
+class MockSSHClient:
+    """A mockup of paramiko.SSHClient, as used in SFTPStrategy.get()."""
+
+    def __enter__(self):
+        """Entry into context manager."""
+        return self
+
+    def __exit__(self, exc_type: object, exc_value: object, traceback: object) -> None:
+        """Dummy exit from context manager."""
+
+    def set_missing_host_key_policy(self, _: object) -> None:
+        """Dummy set_missing_host_key_policy."""
+
+    def connect(self, **_kwargs: object) -> None:
+        """Dummy connect."""
+
+    def open_sftp(self) -> MockSFTPClient:
+        """Return a mock SFTP client."""
+        return MockSFTPClient()
+
+
 def test_sftp(monkeypatch: pytest.MonkeyPatch, static_files: Path) -> None:
     """Test `sftp.py` download strategy by mocking download, and comparing data mock
     downloaded from a local file with data obtained from opening the file directly."""
-    import pysftp
+    import paramiko
 
     from oteapi.datacache.datacache import DataCache
     from oteapi.strategies.download.sftp import SFTPStrategy
 
-    monkeypatch.setattr(pysftp, "Connection", MockSFTPConnection)
+    monkeypatch.setattr(paramiko, "SSHClient", MockSSHClient)
 
     sample_file = static_files / "sample_1280_853.jpeg"
 
@@ -53,7 +71,6 @@ def test_sftp(monkeypatch: pytest.MonkeyPatch, static_files: Path) -> None:
     }
 
     # Call the strategy and get the datacache key
-    # datacache_key: str = SFTPStrategy(config).get().get("key", "")
     datacache_key: str = SFTPStrategy(config).get()["key"]
     # Retrieve the content from the datacache using the key
     datacache = DataCache()


### PR DESCRIPTION
## Summary

Replace the unmaintained `pysftp` dependency with direct `paramiko` calls in the SFTP download strategy, and update the paramiko version constraint from `<4` to `>=4,<6`.
`pysftp 0.2.9` imports `DSSKey` from paramiko at module load time; paramiko 4.0 removed `DSSKey`, causing an `ImportError` whenever `paramiko>=4` is installed.
This also resolves the `pip-audit` CVE-2026-44405 advisory that was blocked by the old `paramiko<4` pin.

## Motivation

Fixes #682

Dependabot PR #678 tried raising `paramiko<4` to `<6`, but all pytest jobs failed with:

```
ImportError: cannot import name 'DSSKey' from 'paramiko'
```

`pysftp 0.2.9` is unmaintained (last release 2016) and will never be updated.
No maintained PyPI fork exists.
The entire role of `pysftp` in this codebase is a thin wrapper around three paramiko calls, making a direct replacement straightforward.

## Changes

### `oteapi/strategies/download/sftp.py`

- Replace `import pysftp` with `import paramiko`
- Replace `pysftp.CnOpts(hostkeys=None)` + `pysftp.Connection(...)` with `paramiko.SSHClient` used as a context manager with `AutoAddPolicy` (equivalent host-key behaviour; `# nosec B507` added as the lax policy is intentional)
- Replace `sftp.get(path, localpath=Path(...))` with `sftp.get(path, str(localpath))`
- Add a runtime guard using falsy checks on `url.host` and `url.path` so both `None` and empty-string values raise a clear error; the message exposes only host and path (not credentials)

### `tests/strategies/download/test_sftp.py`

- Replace `MockSFTPConnection` (patching `pysftp.Connection`) with `MockSSHClient` + `MockSFTPClient` (patching `paramiko.SSHClient`)

### `pyproject.toml`

- Remove `pysftp~=0.2.9` from dependencies
- Change `paramiko<4` → `paramiko>=4,<6` (lower bound ensures we're past the `DSSKey` removal and the CVE; upper bound guards against future breaking changes in 6.x)
- Remove the `filterwarnings` entry for pysftp's `HostKeys` warning (no longer needed)

### `.pre-commit-config.yaml`

- Add `types-paramiko` to the mypy hook's `additional_dependencies` so mypy can type-check paramiko calls

### `.gitignore`

- Add `.claude/` to avoid accidentally committing Claude Code session files

## Test Plan

- [x] `pre-commit run -a` passes with no modifications
- [x] All pytest jobs pass on Windows runners
- [x] Linux pytest jobs: 81 passed — the only error is the pre-existing `test_celery_remote` RabbitMQ 4.x issue addressed separately in PR #681
- [x] `pip-audit` passes — CVE-2026-44405 resolved by `paramiko>=4`